### PR TITLE
Feat: #4 슬라이스 테스트 시 범용적으로 사용되는 클래스를 정의

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     // implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
     compileOnly 'org.projectlombok:lombok'
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
     runtimeOnly group: 'com.h2database', name: 'h2', version: '2.2.224'
     // runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/test/java/com/growup/pms/test/CommonControllerSliceTest.java
+++ b/src/test/java/com/growup/pms/test/CommonControllerSliceTest.java
@@ -1,0 +1,31 @@
+package com.growup.pms.test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.growup.pms.test.annotation.AutoServiceMockBeans;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.ComponentScan.Filter;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.context.WebApplicationContext;
+
+@Slf4j
+@AutoServiceMockBeans(basePackage = "com.growup.pms")
+@WebMvcTest(includeFilters = @Filter(type = FilterType.ANNOTATION, classes = RestController.class))
+public abstract class CommonControllerSliceTest {
+    @Autowired
+    protected MockMvc mockMvc;
+
+    @Autowired
+    protected ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUpEach(WebApplicationContext context) {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(context)
+                .build();
+    }
+}

--- a/src/test/java/com/growup/pms/test/CommonControllerSliceTest.java
+++ b/src/test/java/com/growup/pms/test/CommonControllerSliceTest.java
@@ -2,7 +2,6 @@ package com.growup.pms.test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.growup.pms.test.annotation.AutoServiceMockBeans;
-import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -13,7 +12,6 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.context.WebApplicationContext;
 
-@Slf4j
 @AutoServiceMockBeans(basePackage = "com.growup.pms")
 @WebMvcTest(includeFilters = @Filter(type = FilterType.ANNOTATION, classes = RestController.class))
 public abstract class CommonControllerSliceTest {

--- a/src/test/java/com/growup/pms/test/annotation/AutoServiceMockBeans.java
+++ b/src/test/java/com/growup/pms/test/annotation/AutoServiceMockBeans.java
@@ -1,0 +1,19 @@
+package com.growup.pms.test.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.context.annotation.Import;
+import org.springframework.core.annotation.AliasFor;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Import(ServiceMockBeanRegistrar.class)
+public @interface AutoServiceMockBeans {
+    @AliasFor("value")
+    String basePackage() default "";
+
+    @AliasFor("basePackage")
+    String value() default "";
+}

--- a/src/test/java/com/growup/pms/test/annotation/ServiceMockBeanRegistrar.java
+++ b/src/test/java/com/growup/pms/test/annotation/ServiceMockBeanRegistrar.java
@@ -1,0 +1,50 @@
+package com.growup.pms.test.annotation;
+
+import static org.mockito.Mockito.mock;
+
+import java.util.Objects;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider;
+import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
+import org.springframework.core.type.AnnotationMetadata;
+import org.springframework.core.type.filter.AnnotationTypeFilter;
+import org.springframework.stereotype.Service;
+import org.springframework.util.ClassUtils;
+
+@Slf4j
+public class ServiceMockBeanRegistrar implements ImportBeanDefinitionRegistrar {
+
+    @Override
+    public void registerBeanDefinitions(@NonNull AnnotationMetadata importingClassMetadata, @NonNull BeanDefinitionRegistry registry) {
+        String basePackage = getBasePackage(importingClassMetadata);
+        log.debug("Scanning package: {}", basePackage);
+        registerMockBeans(createScanner(), basePackage, registry);
+    }
+
+    private String getBasePackage(AnnotationMetadata importingClassMetadata) {
+        return (String) Objects.requireNonNull(
+                importingClassMetadata.getAnnotationAttributes(AutoServiceMockBeans.class.getName(), false)).get("value");
+    }
+
+    private ClassPathScanningCandidateComponentProvider createScanner() {
+        ClassPathScanningCandidateComponentProvider scanner = new ClassPathScanningCandidateComponentProvider(false);
+        scanner.addIncludeFilter(new AnnotationTypeFilter(Service.class));
+        return scanner;
+    }
+
+    private void registerMockBeans(ClassPathScanningCandidateComponentProvider scanner, String basePackage, BeanDefinitionRegistry registry) {
+        scanner.findCandidateComponents(basePackage).forEach(beanDefinition -> {
+            String className = beanDefinition.getBeanClassName();
+            try {
+                Class<?> clazz = ClassUtils.forName(className, getClass().getClassLoader());
+                log.debug("Mocking service: {}", clazz.getSimpleName());
+                ((ConfigurableListableBeanFactory) registry).registerSingleton(clazz.getSimpleName(), mock(clazz));
+            } catch (ClassNotFoundException ex) {
+                throw new RuntimeException("Failed to load class: " + className, ex);
+            }
+        });
+    }
+}


### PR DESCRIPTION
## PR Type

- [x] **\[Feat\]** 🎨 새로운 기능을 추가했어요.
- [x] **\[Chore\]** 🛒 빌드 프로세스 변경, 의존성 패키지 업데이트 했어요.

## Related Issues

- close #14 

## What does this PR do?

- [x] 컨텍스트 캐싱을 위해 특정 패키지 아래에 있는 서비스 빈들을 자동으로 찾아서 mocking하는 빈을 구현함
- [x] 테스트 편의를 위해 슬라이스 테스트에서 사용되는 공통된 필드나 작업들을 부모 클래스에서 정의함
- [x] 테스트 환경에서도 롬복을 사용할 수 있도록 의존성을 추가함

## Other information

컨트롤러 슬라이스 테스트 시 아래와 같이 사용할 수 있습니다!

```java
public class MemberApiV1ControllerTest extends CommonControllerSliceTest {
    @Autowired // @MockBean이 아닌 @Autowired를 통해서 이미 mocking된 서비스 빈을 주입받음
    MemberService memberService;

    @Test
    void 비밀번호가_일치하지_않으면_예외가_발생한다() throws Exception {
        // ...
    }
}
```

`@WebMvcTest`를 사용할 때 자동으로 생성되고 초기화되는 `ObjectMapper`나 `MockMvc`와 같이 컨트롤러 테스트에서 공통적으로 사용되는 부분을 `CommonControllerSliceTest`에 정의하였습니다.