### PR TITLE
Config: #17 Jasypt를 사용하여 설정을 암호화함

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -13,6 +13,8 @@ on:
 jobs:
   pr-test:
     runs-on: ubuntu-latest
+    env:
+      JASYPT_PASSWORD: ${{ secrets.JASYPT_PASSWORD }}
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK 21

--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,12 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // https://mvnrepository.com/artifact/com.github.ulisesbocchio/jasypt-spring-boot-starter
+    implementation group: 'com.github.ulisesbocchio', name: 'jasypt-spring-boot-starter', version: '3.0.5'
+    // https://mvnrepository.com/artifact/org.assertj/assertj-core
+    testImplementation 'org.assertj:assertj-core:3.26.0'
+
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -39,9 +39,6 @@ dependencies {
 
     // https://mvnrepository.com/artifact/com.github.ulisesbocchio/jasypt-spring-boot-starter
     implementation group: 'com.github.ulisesbocchio', name: 'jasypt-spring-boot-starter', version: '3.0.5'
-    // https://mvnrepository.com/artifact/org.assertj/assertj-core
-    testImplementation 'org.assertj:assertj-core:3.26.0'
-
 }
 
 tasks.named('test') {

--- a/src/main/java/com/growup/pms/common/config/JasyptConfig.java
+++ b/src/main/java/com/growup/pms/common/config/JasyptConfig.java
@@ -1,0 +1,48 @@
+package com.growup.pms.common.config;
+
+import com.ulisesbocchio.jasyptspringboot.annotation.EnableEncryptableProperties;
+import org.jasypt.encryption.StringEncryptor;
+import org.jasypt.encryption.pbe.PooledPBEStringEncryptor;
+import org.jasypt.encryption.pbe.config.SimpleStringPBEConfig;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableEncryptableProperties
+public class JasyptConfig {
+    
+    // https://github.com/ulisesbocchio/jasypt-spring-boot?tab=readme-ov-file#password-based-encryption-configuration
+    private static final String PASSWORD;
+    private static final String ALGORITHM = "PBEWITHHMACSHA512ANDAES_256";
+    private static final String KEY_OBJECTION_ITERATIONS = "1000";
+    private static final String POOL_SIZE = "1";
+    private static final String PROVIDER_NAME = "SunJCE";
+    private static final String SALT_GENERATOR_CLASS_NAME = "org.jasypt.salt.RandomSaltGenerator";
+    private static final String IV_GENERATOR_CLASS_NAME = "org.jasypt.iv.RandomIvGenerator";
+    private static final String STRING_OUTPUT_TYPE = "base64";
+
+    static {
+        PASSWORD = System.getenv("JASYPT_PASSWORD");
+        if (PASSWORD == null) {
+            throw new IllegalStateException();
+        }
+    }
+
+    @Bean("jasyptEncryptorAES")
+    public StringEncryptor stringEncryptor() {
+        SimpleStringPBEConfig config = new SimpleStringPBEConfig();
+
+        config.setPassword(PASSWORD);
+        config.setAlgorithm(ALGORITHM);
+        config.setKeyObtentionIterations(KEY_OBJECTION_ITERATIONS);
+        config.setPoolSize(POOL_SIZE);
+        config.setProviderName(PROVIDER_NAME);
+        config.setSaltGeneratorClassName(SALT_GENERATOR_CLASS_NAME);
+        config.setIvGeneratorClassName(IV_GENERATOR_CLASS_NAME);
+        config.setStringOutputType(STRING_OUTPUT_TYPE);
+
+        PooledPBEStringEncryptor encryptor = new PooledPBEStringEncryptor();
+        encryptor.setConfig(config);
+        return encryptor;
+    }
+}

--- a/src/main/java/com/growup/pms/common/config/JasyptConfig.java
+++ b/src/main/java/com/growup/pms/common/config/JasyptConfig.java
@@ -1,6 +1,7 @@
 package com.growup.pms.common.config;
 
 import com.ulisesbocchio.jasyptspringboot.annotation.EnableEncryptableProperties;
+import java.util.Objects;
 import org.jasypt.encryption.StringEncryptor;
 import org.jasypt.encryption.pbe.PooledPBEStringEncryptor;
 import org.jasypt.encryption.pbe.config.SimpleStringPBEConfig;
@@ -22,10 +23,7 @@ public class JasyptConfig {
     private static final String STRING_OUTPUT_TYPE = "base64";
 
     static {
-        PASSWORD = System.getenv("JASYPT_PASSWORD");
-        if (PASSWORD == null) {
-            throw new IllegalStateException();
-        }
+        PASSWORD = Objects.requireNonNull(System.getenv("JASYPT_PASSWORD"), "JASYPT_PASSWORD 환경 변수가 설정되지 않았습니다.");
     }
 
     @Bean("jasyptEncryptorAES")

--- a/src/test/java/com/growup/pms/common/config/JasyptConfigTest.java
+++ b/src/test/java/com/growup/pms/common/config/JasyptConfigTest.java
@@ -1,0 +1,39 @@
+package com.growup.pms.common.config;
+
+import org.assertj.core.api.Assertions;
+import org.jasypt.encryption.StringEncryptor;
+import org.jasypt.encryption.pbe.StandardPBEStringEncryptor;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest(classes = {JasyptConfig.class})
+class JasyptConfigTest {
+
+    private final StringEncryptor stringEncryptor;
+
+    public JasyptConfigTest(@Qualifier("jasyptEncryptorAES") StringEncryptor stringEncryptor) {
+        this.stringEncryptor = stringEncryptor;
+    }
+
+
+    @Test
+    @DisplayName("Jasypt를 활용한 암호화를 확인한다.")
+    public void Encrypt(){
+        //given
+        String password = System.getenv("JASYPT_PASSWORD");
+        String plainText = "grow-up-pms";
+
+        //when
+        StandardPBEStringEncryptor standardPBEStringEncryptor = new StandardPBEStringEncryptor();
+        standardPBEStringEncryptor.setPassword(password);
+
+        //then
+        String encryptText = stringEncryptor.encrypt(plainText);
+        String decryptText = this.stringEncryptor.decrypt(encryptText);
+
+        Assertions.assertThat(decryptText).isEqualTo(plainText);
+    }
+
+}

--- a/src/test/java/com/growup/pms/common/config/JasyptConfigTest.java
+++ b/src/test/java/com/growup/pms/common/config/JasyptConfigTest.java
@@ -2,37 +2,33 @@ package com.growup.pms.common.config;
 
 import org.assertj.core.api.Assertions;
 import org.jasypt.encryption.StringEncryptor;
-import org.jasypt.encryption.pbe.StandardPBEStringEncryptor;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@SpringBootTest(classes = {JasyptConfig.class})
+@Import(JasyptConfig.class)
+@ExtendWith(SpringExtension.class)
 class JasyptConfigTest {
 
-    private final StringEncryptor stringEncryptor;
-
-    public JasyptConfigTest(@Qualifier("jasyptEncryptorAES") StringEncryptor stringEncryptor) {
-        this.stringEncryptor = stringEncryptor;
-    }
-
+    @Autowired
+    @Qualifier("jasyptEncryptorAES")
+    private StringEncryptor stringEncryptor;
 
     @Test
     @DisplayName("Jasypt를 활용한 암호화를 확인한다.")
-    public void Encrypt(){
-        //given
-        String password = System.getenv("JASYPT_PASSWORD");
+    void encrypt(){
+        // given
         String plainText = "grow-up-pms";
 
-        //when
-        StandardPBEStringEncryptor standardPBEStringEncryptor = new StandardPBEStringEncryptor();
-        standardPBEStringEncryptor.setPassword(password);
-
-        //then
+        // when
         String encryptText = stringEncryptor.encrypt(plainText);
-        String decryptText = this.stringEncryptor.decrypt(encryptText);
+        String decryptText = stringEncryptor.decrypt(encryptText);
 
+        // then
         Assertions.assertThat(decryptText).isEqualTo(plainText);
     }
 


### PR DESCRIPTION
## PR Type

- [x] **\[Feat\]** 🎨 새로운 기능을 추가했어요.
- [x] **\[Chore\]** 🛒 빌드 프로세스 변경, 의존성 패키지 업데이트 했어요.

## Related Issues

- Close #17 

## What does this PR do?

- [x] Jasypt 의존성을 추가하고 설정함.
- [x] Jasypt 설정을 테스트함.

## Other information
<!--참고한 자료, 추가적인 사항, 기타 의견-->
- Default 알고리즘인 `PBEWITHHMACSHA512ANDAES_256`을 암호 알고리즘으로 사용했어요
   - `https://www.devglan.com/online-tools/jasypt-online-encryption-decryption`를 사용할 수가 없어요.
- 설정을 암호화하기 위해서는 번거로운 작업이 필요할 거 같아요.
   -  일단 사용해보고 다른 라이브러리를 사용하는 것도 좋을 것 같아요!
- [`Password-based Encryption`의 Default Configuration](https://github.com/ulisesbocchio/jasypt-spring-boot?tab=readme-ov-file#password-based-encryption-configuration)

