### PR TITLE
Feat: #41 두 필드가 서로 일치하는지 검증하는 애노테이션을 추가함

### DIFF
--- a/src/main/java/com/growup/pms/common/validation/FieldMatchValidator.java
+++ b/src/main/java/com/growup/pms/common/validation/FieldMatchValidator.java
@@ -1,0 +1,33 @@
+package com.growup.pms.common.validation;
+
+import com.growup.pms.common.validation.constraint.FieldMatch;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import java.util.Objects;
+import org.springframework.beans.BeanWrapper;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.PropertyAccessorFactory;
+
+public class FieldMatchValidator implements ConstraintValidator<FieldMatch, Object> {
+    private String firstFieldName;
+    private String secondFieldName;
+
+    @Override
+    public void initialize(FieldMatch constraintAnnotation) {
+        this.firstFieldName = constraintAnnotation.first();
+        this.secondFieldName = constraintAnnotation.second();
+    }
+
+    @Override
+    public boolean isValid(Object o, ConstraintValidatorContext constraintValidatorContext) {
+        BeanWrapper wrapper = PropertyAccessorFactory.forBeanPropertyAccess(o);
+
+        try {
+            Object firstValue = wrapper.getPropertyValue(firstFieldName);
+            Object secondValue = wrapper.getPropertyValue(secondFieldName);
+            return Objects.equals(firstValue, secondValue);
+        } catch (BeansException e) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/growup/pms/common/validation/constraint/FieldMatch.java
+++ b/src/main/java/com/growup/pms/common/validation/constraint/FieldMatch.java
@@ -1,0 +1,33 @@
+package com.growup.pms.common.validation.constraint;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.TYPE;
+
+import com.growup.pms.common.validation.FieldMatchValidator;
+import jakarta.validation.Constraint;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({TYPE, ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = FieldMatchValidator.class)
+public @interface FieldMatch {
+    String message() default "{com.growup.pms.common.validation.constraint.FieldMatch.message}";
+
+    Class<?>[] groups() default {};
+
+    Class<?>[] payload() default {};
+
+    String first();
+
+    String second();
+
+    @Target({TYPE, ANNOTATION_TYPE})
+    @Retention(RetentionPolicy.RUNTIME)
+    @Documented
+    @interface List {
+        FieldMatch[] value();
+    }
+}

--- a/src/main/java/com/growup/pms/user/dto/UserCreateRequest.java
+++ b/src/main/java/com/growup/pms/user/dto/UserCreateRequest.java
@@ -1,5 +1,6 @@
 package com.growup.pms.user.dto;
 
+import com.growup.pms.common.validation.constraint.FieldMatch;
 import com.growup.pms.user.domain.Provider;
 import com.growup.pms.user.domain.User;
 import com.growup.pms.user.domain.UserProfile;
@@ -13,6 +14,7 @@ import org.hibernate.validator.constraints.Length;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
+@FieldMatch(first = "password", second = "passwordConfirm")
 public class UserCreateRequest {
     @Email
     private String username;

--- a/src/test/java/com/growup/pms/common/validation/FieldMatchValidatorTest.java
+++ b/src/test/java/com/growup/pms/common/validation/FieldMatchValidatorTest.java
@@ -1,0 +1,65 @@
+package com.growup.pms.common.validation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.growup.pms.common.validation.constraint.FieldMatch;
+import com.growup.pms.test.annotation.AutoKoreanDisplayName;
+import com.growup.pms.test.fixture.user.UserCreateRequestFixture;
+import com.growup.pms.test.fixture.user.UserFixture;
+import com.growup.pms.user.dto.UserCreateRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@AutoKoreanDisplayName
+@SuppressWarnings("NonAsciiCharacters")
+@ExtendWith(MockitoExtension.class)
+class FieldMatchValidatorTest {
+    FieldMatchValidator validator;
+
+    @BeforeEach
+    void setUp() {
+        validator = new FieldMatchValidator();
+
+        FieldMatch annotation = mock(FieldMatch.class);
+        when(annotation.first()).thenReturn("password");
+        when(annotation.second()).thenReturn("passwordConfirm");
+
+        validator.initialize(annotation);
+    }
+
+    @Test
+    void 서로_일치하면_유효성_검사가_성공한다() {
+        // given
+        boolean expectedResult = true;
+        UserCreateRequest request = UserCreateRequestFixture.createDefaultRequestBuilder()
+                .password(UserFixture.DEFAULT_PASSWORD)
+                .passwordConfirm(UserFixture.DEFAULT_PASSWORD)
+                .build();
+
+        // when
+        boolean actualResult = validator.isValid(request, null);
+
+        // then
+        assertThat(actualResult).isEqualTo(expectedResult);
+    }
+
+    @Test
+    void 서로_일치하지_않으면_유효성_검사가_실패한다() {
+        // given
+        boolean expectedResult = false;
+        UserCreateRequest request = UserCreateRequestFixture.createDefaultRequestBuilder()
+                .password(UserFixture.DEFAULT_PASSWORD)
+                .passwordConfirm(UserFixture.INVALID_PASSWORD)
+                .build();
+
+        // when
+        boolean actualResult = validator.isValid(request, null);
+
+        // then
+        assertThat(actualResult).isEqualTo(expectedResult);
+    }
+}

--- a/src/test/java/com/growup/pms/test/fixture/user/UserCreateRequestFixture.java
+++ b/src/test/java/com/growup/pms/test/fixture/user/UserCreateRequestFixture.java
@@ -15,6 +15,7 @@ public class UserCreateRequestFixture {
         return UserCreateRequest.builder()
                 .username(user.getUsername())
                 .password(user.getPassword())
+                .passwordConfirm(user.getPassword())
                 .nickname(user.getProfile().getNickname())
                 .content(user.getProfile().getContent())
                 .profileImage(user.getProfile().getProfileImage())
@@ -25,6 +26,7 @@ public class UserCreateRequestFixture {
         return UserCreateRequest.builder()
                 .username(DEFAULT_USERNAME)
                 .password(DEFAULT_PASSWORD)
+                .passwordConfirm(DEFAULT_PASSWORD)
                 .nickname(DEFAULT_NICKNAME)
                 .content(DEFAULT_CONTENT)
                 .profileImage(DEFAULT_PROFILE_IMAGE);


### PR DESCRIPTION
## PR Type

- [x] **\[Feat\]** 🎨 새로운 기능을 추가했어요.
- [x] **\[Test\]** 🧪 테스트 코드를 추가/삭제/변경 했어요.

## Related Issues

- close #41 

## What does this PR do?

- [x] 두 필드가 서로 일치하는지 검증하는 `@FieldMatch` 애노테이션 추가
- [x] 애노테이션 검증기에 대한 단위 테스트를 작성함
- [x] 회원가입 시 비밀번호와 비밀번호 확인이 일치하지 않으면 예외가 발생하도록 수정함

## Other information
이 `@FieldMatch` 애노테이션은 `first`와 `second`에 각각 필드명을 명시하면, 두 필드의 값이 서로 일치하는지 검사합니다.

```java
@Getter
@NoArgsConstructor(access = AccessLevel.PRIVATE)
@FieldMatch(first = "password", second = "passwordConfirm")
public class UserCreateRequest {
    @Email
    private String username;

    @Length(min = 8, max = 20)
    private String password;

    private String passwordConfirm;
    ...
}
```
