### PR TITLE
Feat: #23 일반 로그인 기능을 구현함

### DIFF
--- a/src/main/java/com/growup/pms/auth/controller/AuthenticationControllerV1.java
+++ b/src/main/java/com/growup/pms/auth/controller/AuthenticationControllerV1.java
@@ -1,0 +1,42 @@
+package com.growup.pms.auth.controller;
+
+import com.growup.pms.auth.dto.AccessTokenResponse;
+import com.growup.pms.auth.dto.SignInRequest;
+import com.growup.pms.auth.dto.TokenDto;
+import com.growup.pms.auth.service.JwtLoginService;
+import com.growup.pms.common.security.jwt.JwtTokenProvider;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/auth")
+@RequiredArgsConstructor
+public class AuthenticationControllerV1 {
+    private final JwtLoginService loginService;
+    private final JwtTokenProvider tokenProvider;
+
+    @PostMapping("/login")
+    public ResponseEntity<AccessTokenResponse> login(@Valid @RequestBody SignInRequest request, HttpServletResponse response) {
+        TokenDto tokenDto = loginService.authenticateUser(request);
+        setRefreshTokenCookie(response, tokenDto.getRefreshToken());
+        return ResponseEntity.ok()
+                .body(new AccessTokenResponse(tokenDto.getAccessToken()));
+    }
+
+    private void setRefreshTokenCookie(HttpServletResponse response, String refreshToken) {
+        Cookie refreshTokenCookie = new Cookie("refresh_token", refreshToken);
+        refreshTokenCookie.setHttpOnly(true);
+        // TODO: 서비스가 HTTPS로 배포된 후에 보안 강화를 위해 주석을 해제해야 함
+        // refreshTokenCookie.setSecure(true);
+        refreshTokenCookie.setPath("/");
+        refreshTokenCookie.setMaxAge((int) (tokenProvider.refreshTokenExpirationTime / 1000));
+        response.addCookie(refreshTokenCookie);
+    }
+}

--- a/src/main/java/com/growup/pms/auth/domain/SecurityUser.java
+++ b/src/main/java/com/growup/pms/auth/domain/SecurityUser.java
@@ -1,0 +1,39 @@
+package com.growup.pms.auth.domain;
+
+import java.util.Collection;
+import java.util.Collections;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+public class SecurityUser implements UserDetails {
+    @Getter
+    private final Long id;
+
+    private final String username;
+
+    private final String password;
+
+    @Builder
+    public SecurityUser(Long id, String username, String password) {
+        this.id = id;
+        this.username = username;
+        this.password = password;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public String getPassword() {
+        return password;
+    }
+
+    @Override
+    public String getUsername() {
+        return username;
+    }
+}

--- a/src/main/java/com/growup/pms/auth/dto/AccessTokenResponse.java
+++ b/src/main/java/com/growup/pms/auth/dto/AccessTokenResponse.java
@@ -1,0 +1,17 @@
+package com.growup.pms.auth.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class AccessTokenResponse {
+    @JsonProperty("access_token")
+    private String accessToken;
+
+    public AccessTokenResponse(String accessToken) {
+        this.accessToken = accessToken;
+    }
+}

--- a/src/main/java/com/growup/pms/auth/dto/SignInRequest.java
+++ b/src/main/java/com/growup/pms/auth/dto/SignInRequest.java
@@ -1,0 +1,20 @@
+package com.growup.pms.auth.dto;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class SignInRequest {
+    private String username;
+
+    private String password;
+
+    @Builder
+    public SignInRequest(String username, String password) {
+        this.username = username;
+        this.password = password;
+    }
+}

--- a/src/main/java/com/growup/pms/auth/dto/TokenDto.java
+++ b/src/main/java/com/growup/pms/auth/dto/TokenDto.java
@@ -1,0 +1,19 @@
+package com.growup.pms.auth.dto;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class TokenDto {
+    private String accessToken;
+    private String refreshToken;
+
+    @Builder
+    public TokenDto(String accessToken, String refreshToken) {
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+    }
+}

--- a/src/main/java/com/growup/pms/auth/service/CustomUserDetailsService.java
+++ b/src/main/java/com/growup/pms/auth/service/CustomUserDetailsService.java
@@ -1,0 +1,25 @@
+package com.growup.pms.auth.service;
+
+import com.growup.pms.auth.domain.SecurityUser;
+import com.growup.pms.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        var user = userRepository.findByUsernameOrThrow(username);
+        return SecurityUser.builder()
+                .id(user.getId())
+                .username(user.getUsername())
+                .password(user.getPassword())
+                .build();
+    }
+}

--- a/src/main/java/com/growup/pms/auth/service/JwtLoginService.java
+++ b/src/main/java/com/growup/pms/auth/service/JwtLoginService.java
@@ -1,0 +1,24 @@
+package com.growup.pms.auth.service;
+
+import com.growup.pms.auth.domain.SecurityUser;
+import com.growup.pms.auth.dto.SignInRequest;
+import com.growup.pms.auth.dto.TokenDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class JwtLoginService {
+    private final AuthenticationManagerBuilder authenticationManagerBuilder;
+    private final JwtTokenService jwtTokenService;
+
+    public TokenDto authenticateUser(SignInRequest request) {
+        var authenticationToken = new UsernamePasswordAuthenticationToken(request.getUsername(), request.getPassword());
+        Authentication authentication = authenticationManagerBuilder.getObject()
+                .authenticate(authenticationToken);
+        return jwtTokenService.generateJwtTokens(((SecurityUser) authentication.getPrincipal()).getId(), authentication);
+    }
+}

--- a/src/main/java/com/growup/pms/auth/service/JwtTokenService.java
+++ b/src/main/java/com/growup/pms/auth/service/JwtTokenService.java
@@ -1,0 +1,20 @@
+package com.growup.pms.auth.service;
+
+import com.growup.pms.auth.dto.TokenDto;
+import com.growup.pms.common.security.jwt.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class JwtTokenService {
+    private final JwtTokenProvider tokenProvider;
+
+    public TokenDto generateJwtTokens(Long userId, Authentication authentication) {
+        return TokenDto.builder()
+                .accessToken(tokenProvider.createAccessToken(userId, authentication))
+                .refreshToken(tokenProvider.createRefreshToken(userId, authentication))
+                .build();
+    }
+}

--- a/src/main/java/com/growup/pms/common/exception/code/ErrorCategory.java
+++ b/src/main/java/com/growup/pms/common/exception/code/ErrorCategory.java
@@ -9,7 +9,8 @@ public enum ErrorCategory {
     ENTITY_ERROR("ET_", "Entity error: "),
     AUTHENTICATION_ERROR("AT_", "Authentication error: "),
     AUTHORIZATION_ERROR("ATZ_", "Authorization error: "),
-    INTERNAL_SERVER_ERROR("IS_", "Internal server error: ");
+    INTERNAL_SERVER_ERROR("IS_", "Internal server error: "),
+    DATA_FORMAT_ERROR("DF_", "Data format error: ");
 
     private final String codePrefix;
     private final String messagePrefix;

--- a/src/main/java/com/growup/pms/common/exception/code/ErrorCode.java
+++ b/src/main/java/com/growup/pms/common/exception/code/ErrorCode.java
@@ -14,7 +14,9 @@ public enum ErrorCode {
 
     AUTHZ_ACCESS_DENIED(ErrorCategory.AUTHORIZATION_ERROR, "001", "접근 권한이 없습니다."),
 
-    INTERNAL_SERVER_ERROR(ErrorCategory.INTERNAL_SERVER_ERROR, "001", "예상치 못한 서버 에러가 발생했습니다.");
+    INTERNAL_SERVER_ERROR(ErrorCategory.INTERNAL_SERVER_ERROR, "001", "예상치 못한 서버 에러가 발생했습니다."),
+
+    DATA_FORMAT_INVALID(ErrorCategory.DATA_FORMAT_ERROR, "001", "데이터 형식이 잘못되었습니다.");
 
     private final ErrorCategory errorCategory;
     private final String code;

--- a/src/test/java/com/growup/pms/auth/controller/AuthenticationControllerV1Test.java
+++ b/src/test/java/com/growup/pms/auth/controller/AuthenticationControllerV1Test.java
@@ -1,0 +1,71 @@
+package com.growup.pms.auth.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.growup.pms.auth.dto.SignInRequest;
+import com.growup.pms.auth.dto.TokenDto;
+import com.growup.pms.auth.service.JwtLoginService;
+import com.growup.pms.common.exception.code.ErrorCode;
+import com.growup.pms.common.exception.exceptions.EntityNotFoundException;
+import com.growup.pms.test.CommonControllerSliceTest;
+import com.growup.pms.test.annotation.AutoKoreanDisplayName;
+import com.growup.pms.test.fixture.auth.SignInRequestFixture;
+import com.growup.pms.test.fixture.auth.TokenDtoFixture;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+
+@AutoKoreanDisplayName
+@SuppressWarnings("NonAsciiCharacters")
+class AuthenticationControllerV1Test extends CommonControllerSliceTest {
+
+    @Autowired
+    private JwtLoginService loginService;
+
+    @Nested
+    class 사용자가_로그인_시에 {
+
+        @Test
+        void 성공한다() throws Exception {
+            // given
+            SignInRequest validRequest = SignInRequestFixture.createDefaultRequest();
+            TokenDto expectedValidToken = TokenDtoFixture.createDefaultDtoBuilder()
+                    .accessToken(TokenDtoFixture.VALID_ACCESS_TOKEN)
+                    .refreshToken(TokenDtoFixture.VALID_REFRESH_TOKEN)
+                    .build();
+
+            when(loginService.authenticateUser(any(SignInRequest.class))).thenReturn(expectedValidToken);
+
+            // when & then
+            mockMvc.perform(post("/api/v1/auth/login")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(validRequest)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.access_token").value(TokenDtoFixture.VALID_ACCESS_TOKEN))
+                    .andExpect(cookie().value("refresh_token", TokenDtoFixture.VALID_REFRESH_TOKEN));
+        }
+
+        @Test
+        void 매치되는_정보가_없으면_예외가_발생한다() throws Exception {
+            // given
+            SignInRequest badRequest = SignInRequestFixture.createDefaultRequest();
+
+            doThrow(new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND)).when(loginService).authenticateUser(any(SignInRequest.class));
+
+            // when & then
+            mockMvc.perform(post("/api/v1/auth/login")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(badRequest)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.access_token").doesNotExist())
+                    .andExpect(cookie().doesNotExist("refresh_token"));
+        }
+    }
+}

--- a/src/test/java/com/growup/pms/auth/controller/AuthenticationControllerV1Test.java
+++ b/src/test/java/com/growup/pms/auth/controller/AuthenticationControllerV1Test.java
@@ -25,7 +25,6 @@ import org.springframework.http.MediaType;
 @AutoKoreanDisplayName
 @SuppressWarnings("NonAsciiCharacters")
 class AuthenticationControllerV1Test extends CommonControllerSliceTest {
-
     @Autowired
     private JwtLoginService loginService;
 

--- a/src/test/java/com/growup/pms/auth/service/JwtLoginServiceTest.java
+++ b/src/test/java/com/growup/pms/auth/service/JwtLoginServiceTest.java
@@ -1,0 +1,97 @@
+package com.growup.pms.auth.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.growup.pms.auth.domain.SecurityUser;
+import com.growup.pms.auth.dto.SignInRequest;
+import com.growup.pms.auth.dto.TokenDto;
+import com.growup.pms.test.annotation.AutoKoreanDisplayName;
+import com.growup.pms.test.fixture.auth.SignInRequestFixture;
+import com.growup.pms.test.fixture.auth.TokenDtoFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.core.Authentication;
+
+@AutoKoreanDisplayName
+@SuppressWarnings("NonAsciiCharacters")
+@ExtendWith(MockitoExtension.class)
+class JwtLoginServiceTest {
+    @Mock
+    AuthenticationManagerBuilder authenticationManagerBuilder;
+
+    @Mock
+    AuthenticationManager authenticationManager;
+
+    @Mock
+    Authentication authentication;
+
+    @Mock
+    SecurityUser securityUser;
+
+    @Mock
+    JwtTokenService tokenService;
+
+    @InjectMocks
+    JwtLoginService loginService;
+
+    @BeforeEach
+    void setUp() {
+        when(authenticationManagerBuilder.getObject()).thenReturn(authenticationManager);
+    }
+
+    @Nested
+    class 사용자가_인증에 {
+
+        @Test
+        void 성공한다() {
+            // given
+            Long userId = 1L;
+            SignInRequest validRequest = SignInRequestFixture.createDefaultRequest();
+            UsernamePasswordAuthenticationToken token = new UsernamePasswordAuthenticationToken(validRequest.getUsername(), validRequest.getPassword());
+            TokenDto expectedToken = TokenDtoFixture.createDefaultDto();
+
+            when(authenticationManager.authenticate(token)).thenReturn(authentication);
+            when(authentication.getPrincipal()).thenReturn(securityUser);
+            when(securityUser.getId()).thenReturn(userId);
+            when(tokenService.generateJwtTokens(userId, authentication)).thenReturn(expectedToken);
+
+            // when
+            TokenDto actualToken = loginService.authenticateUser(validRequest);
+
+            // then
+            assertThat(actualToken).isNotNull();
+            assertThat(expectedToken.getAccessToken()).isEqualTo(actualToken.getAccessToken());
+            assertThat(expectedToken.getRefreshToken()).isEqualTo(actualToken.getRefreshToken());
+
+            verify(authenticationManager).authenticate(token);
+            verify(tokenService).generateJwtTokens(userId, authentication);
+        }
+
+        @Test
+        void 실패하면_예외가_발생한다() {
+            // given
+            SignInRequest badRequest = SignInRequestFixture.createDefaultRequest();
+            UsernamePasswordAuthenticationToken token = new UsernamePasswordAuthenticationToken(badRequest.getUsername(), badRequest.getPassword());
+
+            doThrow(new RuntimeException()).when(authenticationManager).authenticate(token);
+
+            // when & then
+            assertThatThrownBy(() -> loginService.authenticateUser(badRequest))
+                    .isInstanceOf(RuntimeException.class);
+
+            verify(authenticationManager).authenticate(token);
+        }
+    }
+}

--- a/src/test/java/com/growup/pms/auth/service/JwtTokenServiceTest.java
+++ b/src/test/java/com/growup/pms/auth/service/JwtTokenServiceTest.java
@@ -1,0 +1,52 @@
+package com.growup.pms.auth.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+
+import com.growup.pms.auth.dto.TokenDto;
+import com.growup.pms.common.security.jwt.JwtTokenProvider;
+import com.growup.pms.test.annotation.AutoKoreanDisplayName;
+import com.growup.pms.test.fixture.auth.TokenDtoFixture;
+import com.growup.pms.test.fixture.user.UserFixture;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+
+@AutoKoreanDisplayName
+@SuppressWarnings("NonAsciiCharacters")
+@ExtendWith(MockitoExtension.class)
+class JwtTokenServiceTest {
+    @Mock
+    private JwtTokenProvider tokenProvider;
+
+    @InjectMocks
+    private JwtTokenService tokenService;
+
+    @Test
+    void 토큰을_새롭게_생성한다() {
+        // given
+        Authentication authentication = new UsernamePasswordAuthenticationToken(
+                UserFixture.DEFAULT_USERNAME, UserFixture.DEFAULT_PASSWORD, Collections.emptyList());
+        TokenDto expectedTokenDto = TokenDtoFixture.createDefaultDtoBuilder()
+                        .accessToken(TokenDtoFixture.NEW_ACCESS_TOKEN)
+                        .refreshToken(TokenDtoFixture.NEW_REFRESH_TOKEN)
+                        .build();
+
+        when(tokenProvider.createAccessToken(anyLong(), any(Authentication.class))).thenReturn(TokenDtoFixture.NEW_ACCESS_TOKEN);
+        when(tokenProvider.createRefreshToken(anyLong(), any(Authentication.class))).thenReturn(TokenDtoFixture.NEW_REFRESH_TOKEN);
+
+        // when
+        TokenDto actualTokenDto = tokenService.generateJwtTokens(0L, authentication);
+
+        // then
+        assertThat(actualTokenDto.getAccessToken()).isEqualTo(expectedTokenDto.getAccessToken());
+        assertThat(actualTokenDto.getRefreshToken()).isEqualTo(expectedTokenDto.getRefreshToken());
+    }
+}

--- a/src/test/java/com/growup/pms/test/fixture/auth/SignInRequestFixture.java
+++ b/src/test/java/com/growup/pms/test/fixture/auth/SignInRequestFixture.java
@@ -1,0 +1,19 @@
+package com.growup.pms.test.fixture.auth;
+
+import static com.growup.pms.test.fixture.user.UserFixture.DEFAULT_PASSWORD;
+import static com.growup.pms.test.fixture.user.UserFixture.DEFAULT_USERNAME;
+
+import com.growup.pms.auth.dto.SignInRequest;
+
+public class SignInRequestFixture {
+
+    public static SignInRequest createDefaultRequest() {
+        return createDefaultRequestBuilder().build();
+    }
+
+    public static SignInRequest.SignInRequestBuilder createDefaultRequestBuilder() {
+        return SignInRequest.builder()
+                .username(DEFAULT_USERNAME)
+                .password(DEFAULT_PASSWORD);
+    }
+}

--- a/src/test/java/com/growup/pms/test/fixture/auth/TokenDtoFixture.java
+++ b/src/test/java/com/growup/pms/test/fixture/auth/TokenDtoFixture.java
@@ -13,6 +13,10 @@ public class TokenDtoFixture {
     public static final String NEW_ACCESS_TOKEN = "newAccessToken";
     public static final String NEW_REFRESH_TOKEN = "newRefreshToken";
 
+    public static TokenDto createDefaultDto() {
+        return createDefaultDtoBuilder().build();
+    }
+
     public static TokenDto.TokenDtoBuilder createDefaultDtoBuilder() {
         return TokenDto.builder()
                 .accessToken(VALID_ACCESS_TOKEN)

--- a/src/test/java/com/growup/pms/test/fixture/auth/TokenDtoFixture.java
+++ b/src/test/java/com/growup/pms/test/fixture/auth/TokenDtoFixture.java
@@ -1,0 +1,21 @@
+package com.growup.pms.test.fixture.auth;
+
+import com.growup.pms.auth.dto.TokenDto;
+
+public class TokenDtoFixture {
+
+    public static final String VALID_ACCESS_TOKEN = "validAccessToken";
+    public static final String VALID_REFRESH_TOKEN = "validRefreshToken";
+
+    public static final String INVALID_ACCESS_TOKEN = "invalidAccessToken";
+    public static final String INVALID_REFRESH_TOKEN = "invalidRefreshToken";
+
+    public static final String NEW_ACCESS_TOKEN = "newAccessToken";
+    public static final String NEW_REFRESH_TOKEN = "newRefreshToken";
+
+    public static TokenDto.TokenDtoBuilder createDefaultDtoBuilder() {
+        return TokenDto.builder()
+                .accessToken(VALID_ACCESS_TOKEN)
+                .refreshToken(VALID_REFRESH_TOKEN);
+    }
+}

--- a/src/test/java/com/growup/pms/user/service/UserServiceTest.java
+++ b/src/test/java/com/growup/pms/user/service/UserServiceTest.java
@@ -36,7 +36,7 @@ class UserServiceTest {
     PasswordEncoder passwordEncoder;
 
     @Nested
-    class 사용자가 {
+    class 사용자가_회원가입_시에 {
 
         @Test
         void 성공적으로_계정을_생성한다() {


### PR DESCRIPTION
## PR Type

- [x] **\[Feat\]** 🎨 새로운 기능을 추가했어요.
- [x] **\[Style\]** 🧬 코드 스타일 업데이트를 했어요(포맷팅, 변수명 변경 etc)
- [x] **\[Test\]** 🧪 테스트 코드를 추가/삭제/변경 했어요.

## Related Issues

- close #23 

## What does this PR do?

- [x] 로그인 API 엔드포인트 정의(`POST /api/v1/auth/login`)
- [x] 편의를 위해 JWT의 페이로드에 사용자 ID를 포함시킴
- [x] 테스트 작성
  - [x] 인증 컨트롤러에 대한 슬라이스 테스트를 작성함
  - [x] 로그인 서비스에 대한 단위 테스트를 작성함

## Other information

- 리프레시 토큰을 DB에 저장하거나 제거하는 등의 기능은 토큰을 재발급 받는 API를 구현할 때 같이 작업하도록 하겠습니다!