### PR TITLE
Fix: #50 보안 권고사항에 따라서 JWT의 비밀 키를 512비트 이상으로 수정함

### DIFF
--- a/src/main/java/com/growup/pms/common/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/growup/pms/common/security/jwt/JwtTokenProvider.java
@@ -1,5 +1,6 @@
 package com.growup.pms.common.security.jwt;
 
+import com.growup.pms.auth.domain.SecurityUser;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.JwtException;
@@ -19,7 +20,6 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.userdetails.User;
 import org.springframework.stereotype.Component;
 
 @Slf4j
@@ -101,7 +101,7 @@ public class JwtTokenProvider {
                         .filter(auth -> !auth.isEmpty())
                         .map(SimpleGrantedAuthority::new)
                         .toList();
-        User principal = new User(claims.getSubject(), "", authorities);
+        SecurityUser principal = new SecurityUser(claims.get(USER_ID_KEY, Long.class), claims.getSubject(), "");
         return new UsernamePasswordAuthenticationToken(principal, token, authorities);
     }
 

--- a/src/main/resources/application-common.yml
+++ b/src/main/resources/application-common.yml
@@ -11,6 +11,6 @@ jasypt:
 
 security:
   jwt:
-    base64-secret: ENC(IAOzDB87WA/evdFrSSzDsmgtpFC+fIev+ckx+Qb3+KFwLpCPInk8oPxILwE33IdUchcesVhpzuO1PjKaIqFAOZINbJniiuuzr/PZ0FSDhYM=)
+    base64-secret: ENC(GsF8xZqjhZEphkvkgkKHDS23D6xo73+8iBGBJH1zSm1L9YBsHth1HdjMBivz3ljMSNTLDl+ZzlEw9UClhNemX+AmN0eVomJfo93VX6tZk5KWqAGhGk9X8hrCJnZluFFsjjMBd2+tJ13NHHigXpGxT+OxeziTgJWz0OP+vHLoNgQ=)
     access-expiration-time: 86400000
     refresh-expiration-time: 604800000


### PR DESCRIPTION
## PR Type

- [x] **\[Fix\]** 🐞 버그를 수정했어요.

## Related Issues

- close #50 

## What does this PR do?

- [x] JWT의 비밀 키를 256비트에서 512비트로 수정함
- [x] User 구현체 대신에 SecurityUser 구현체를 사용하도록 수정함