### PR TITLE
Feat: #45 리프레시 토큰을 통해 토큰을 재발급하는 API를 추가함

### DIFF
--- a/src/main/java/com/growup/pms/auth/controller/AuthenticationControllerV1.java
+++ b/src/main/java/com/growup/pms/auth/controller/AuthenticationControllerV1.java
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/v1/auth")
+@RequestMapping("/api/v1/user")
 @RequiredArgsConstructor
 public class AuthenticationControllerV1 {
     private final JwtLoginService loginService;

--- a/src/main/java/com/growup/pms/auth/controller/AuthenticationControllerV1.java
+++ b/src/main/java/com/growup/pms/auth/controller/AuthenticationControllerV1.java
@@ -1,7 +1,7 @@
 package com.growup.pms.auth.controller;
 
 import com.growup.pms.auth.dto.AccessTokenResponse;
-import com.growup.pms.auth.dto.SignInRequest;
+import com.growup.pms.auth.dto.LoginRequest;
 import com.growup.pms.auth.dto.TokenDto;
 import com.growup.pms.auth.service.JwtLoginService;
 import com.growup.pms.common.security.jwt.JwtTokenProvider;
@@ -23,7 +23,7 @@ public class AuthenticationControllerV1 {
     private final JwtTokenProvider tokenProvider;
 
     @PostMapping("/login")
-    public ResponseEntity<AccessTokenResponse> login(@Valid @RequestBody SignInRequest request, HttpServletResponse response) {
+    public ResponseEntity<AccessTokenResponse> login(@Valid @RequestBody LoginRequest request, HttpServletResponse response) {
         TokenDto tokenDto = loginService.authenticateUser(request);
         setRefreshTokenCookie(response, tokenDto.getRefreshToken());
         return ResponseEntity.ok()

--- a/src/main/java/com/growup/pms/auth/controller/LoginControllerV1.java
+++ b/src/main/java/com/growup/pms/auth/controller/LoginControllerV1.java
@@ -30,14 +30,14 @@ public class LoginControllerV1 {
         TokenDto tokenDto = loginService.authenticateUser(request);
         setRefreshTokenCookie(response, tokenDto.getRefreshToken());
         return ResponseEntity.ok()
-                .body(new AccessTokenResponse(tokenDto.getAccessToken()));
+                .body(AccessTokenResponse.builder().accessToken(tokenDto.getAccessToken()).build());
     }
 
     @PostMapping("/refresh")
     public ResponseEntity<AccessTokenResponse> refresh(@CookieValue("refreshToken") String refreshToken, HttpServletResponse response) {
         TokenDto tokenDto = tokenService.refreshJwtTokens(refreshToken);
         setRefreshTokenCookie(response, tokenDto.getRefreshToken());
-        return ResponseEntity.ok().body(new AccessTokenResponse(tokenDto.getAccessToken()));
+        return ResponseEntity.ok().body(AccessTokenResponse.builder().accessToken(tokenDto.getAccessToken()).build());
     }
 
     private void setRefreshTokenCookie(HttpServletResponse response, String refreshToken) {

--- a/src/main/java/com/growup/pms/auth/controller/LoginControllerV1.java
+++ b/src/main/java/com/growup/pms/auth/controller/LoginControllerV1.java
@@ -4,25 +4,28 @@ import com.growup.pms.auth.dto.AccessTokenResponse;
 import com.growup.pms.auth.dto.LoginRequest;
 import com.growup.pms.auth.dto.TokenDto;
 import com.growup.pms.auth.service.JwtLoginService;
+import com.growup.pms.auth.service.JwtTokenService;
 import com.growup.pms.common.security.jwt.JwtTokenProvider;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/v1/user")
+@RequestMapping("/api/v1/user/login")
 @RequiredArgsConstructor
-public class AuthenticationControllerV1 {
+public class LoginControllerV1 {
     private final JwtLoginService loginService;
     private final JwtTokenProvider tokenProvider;
+    private final JwtTokenService tokenService;
 
-    @PostMapping("/login")
+    @PostMapping
     public ResponseEntity<AccessTokenResponse> login(@Valid @RequestBody LoginRequest request, HttpServletResponse response) {
         TokenDto tokenDto = loginService.authenticateUser(request);
         setRefreshTokenCookie(response, tokenDto.getRefreshToken());
@@ -30,8 +33,15 @@ public class AuthenticationControllerV1 {
                 .body(new AccessTokenResponse(tokenDto.getAccessToken()));
     }
 
+    @PostMapping("/refresh")
+    public ResponseEntity<AccessTokenResponse> refresh(@CookieValue("refreshToken") String refreshToken, HttpServletResponse response) {
+        TokenDto tokenDto = tokenService.refreshJwtTokens(refreshToken);
+        setRefreshTokenCookie(response, tokenDto.getRefreshToken());
+        return ResponseEntity.ok().body(new AccessTokenResponse(tokenDto.getAccessToken()));
+    }
+
     private void setRefreshTokenCookie(HttpServletResponse response, String refreshToken) {
-        Cookie refreshTokenCookie = new Cookie("refresh_token", refreshToken);
+        Cookie refreshTokenCookie = new Cookie("refreshToken", refreshToken);
         refreshTokenCookie.setHttpOnly(true);
         // TODO: 서비스가 HTTPS로 배포된 후에 보안 강화를 위해 주석을 해제해야 함
         // refreshTokenCookie.setSecure(true);

--- a/src/main/java/com/growup/pms/auth/domain/RefreshToken.java
+++ b/src/main/java/com/growup/pms/auth/domain/RefreshToken.java
@@ -1,0 +1,42 @@
+package com.growup.pms.auth.domain;
+
+import com.growup.pms.user.domain.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "refresh_tokens")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RefreshToken {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "refresh_token_id")
+    private Long id;
+
+    @OneToOne
+    @JoinColumn(name = "user_id", unique = true)
+    private User user;
+
+    private String token;
+
+    private Instant expiryDate;
+
+    @Builder
+    public RefreshToken(User user, String token, Instant expiryDate) {
+        this.user = user;
+        this.token = token;
+        this.expiryDate = expiryDate;
+    }
+}

--- a/src/main/java/com/growup/pms/auth/domain/SecurityUser.java
+++ b/src/main/java/com/growup/pms/auth/domain/SecurityUser.java
@@ -11,14 +11,14 @@ public class SecurityUser implements UserDetails {
     @Getter
     private final Long id;
 
-    private final String username;
+    private final String email;
 
     private final String password;
 
     @Builder
-    public SecurityUser(Long id, String username, String password) {
+    public SecurityUser(Long id, String email, String password) {
         this.id = id;
-        this.username = username;
+        this.email = email;
         this.password = password;
     }
 
@@ -34,6 +34,6 @@ public class SecurityUser implements UserDetails {
 
     @Override
     public String getUsername() {
-        return username;
+        return email;
     }
 }

--- a/src/main/java/com/growup/pms/auth/dto/AccessTokenResponse.java
+++ b/src/main/java/com/growup/pms/auth/dto/AccessTokenResponse.java
@@ -8,7 +8,6 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class AccessTokenResponse {
-    @JsonProperty("access_token")
     private String accessToken;
 
     public AccessTokenResponse(String accessToken) {

--- a/src/main/java/com/growup/pms/auth/dto/AccessTokenResponse.java
+++ b/src/main/java/com/growup/pms/auth/dto/AccessTokenResponse.java
@@ -2,6 +2,7 @@ package com.growup.pms.auth.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -10,6 +11,7 @@ import lombok.NoArgsConstructor;
 public class AccessTokenResponse {
     private String accessToken;
 
+    @Builder
     public AccessTokenResponse(String accessToken) {
         this.accessToken = accessToken;
     }

--- a/src/main/java/com/growup/pms/auth/dto/AccessTokenResponse.java
+++ b/src/main/java/com/growup/pms/auth/dto/AccessTokenResponse.java
@@ -1,6 +1,5 @@
 package com.growup.pms.auth.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/growup/pms/auth/dto/LoginRequest.java
+++ b/src/main/java/com/growup/pms/auth/dto/LoginRequest.java
@@ -7,13 +7,13 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
-public class SignInRequest {
+public class LoginRequest {
     private String username;
 
     private String password;
 
     @Builder
-    public SignInRequest(String username, String password) {
+    public LoginRequest(String username, String password) {
         this.username = username;
         this.password = password;
     }

--- a/src/main/java/com/growup/pms/auth/dto/LoginRequest.java
+++ b/src/main/java/com/growup/pms/auth/dto/LoginRequest.java
@@ -8,13 +8,12 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class LoginRequest {
-    private String username;
-
+    private String email;
     private String password;
 
     @Builder
-    public LoginRequest(String username, String password) {
-        this.username = username;
+    public LoginRequest(String email, String password) {
+        this.email = email;
         this.password = password;
     }
 }

--- a/src/main/java/com/growup/pms/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/growup/pms/auth/repository/RefreshTokenRepository.java
@@ -1,0 +1,11 @@
+package com.growup.pms.auth.repository;
+
+import com.growup.pms.auth.domain.RefreshToken;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+    Long deleteByUserId(Long userId);
+
+    Optional<RefreshToken> findByUserIdAndToken(Long userId, String token);
+}

--- a/src/main/java/com/growup/pms/auth/service/CustomUserDetailsService.java
+++ b/src/main/java/com/growup/pms/auth/service/CustomUserDetailsService.java
@@ -18,7 +18,7 @@ public class CustomUserDetailsService implements UserDetailsService {
         var user = userRepository.findByUsernameOrThrow(username);
         return SecurityUser.builder()
                 .id(user.getId())
-                .username(user.getUsername())
+                .email(user.getEmail())
                 .password(user.getPassword())
                 .build();
     }

--- a/src/main/java/com/growup/pms/auth/service/CustomUserDetailsService.java
+++ b/src/main/java/com/growup/pms/auth/service/CustomUserDetailsService.java
@@ -15,7 +15,7 @@ public class CustomUserDetailsService implements UserDetailsService {
 
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        var user = userRepository.findByUsernameOrThrow(username);
+        var user = userRepository.findByEmailOrThrow(username);
         return SecurityUser.builder()
                 .id(user.getId())
                 .email(user.getEmail())

--- a/src/main/java/com/growup/pms/auth/service/JwtLoginService.java
+++ b/src/main/java/com/growup/pms/auth/service/JwtLoginService.java
@@ -16,7 +16,7 @@ public class JwtLoginService {
     private final JwtTokenService jwtTokenService;
 
     public TokenDto authenticateUser(LoginRequest request) {
-        var authenticationToken = new UsernamePasswordAuthenticationToken(request.getUsername(), request.getPassword());
+        var authenticationToken = new UsernamePasswordAuthenticationToken(request.getEmail(), request.getPassword());
         Authentication authentication = authenticationManagerBuilder.getObject()
                 .authenticate(authenticationToken);
         return jwtTokenService.generateJwtTokens(((SecurityUser) authentication.getPrincipal()).getId(), authentication);

--- a/src/main/java/com/growup/pms/auth/service/JwtLoginService.java
+++ b/src/main/java/com/growup/pms/auth/service/JwtLoginService.java
@@ -1,7 +1,7 @@
 package com.growup.pms.auth.service;
 
 import com.growup.pms.auth.domain.SecurityUser;
-import com.growup.pms.auth.dto.SignInRequest;
+import com.growup.pms.auth.dto.LoginRequest;
 import com.growup.pms.auth.dto.TokenDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -15,7 +15,7 @@ public class JwtLoginService {
     private final AuthenticationManagerBuilder authenticationManagerBuilder;
     private final JwtTokenService jwtTokenService;
 
-    public TokenDto authenticateUser(SignInRequest request) {
+    public TokenDto authenticateUser(LoginRequest request) {
         var authenticationToken = new UsernamePasswordAuthenticationToken(request.getUsername(), request.getPassword());
         Authentication authentication = authenticationManagerBuilder.getObject()
                 .authenticate(authenticationToken);

--- a/src/main/java/com/growup/pms/auth/service/JwtTokenService.java
+++ b/src/main/java/com/growup/pms/auth/service/JwtTokenService.java
@@ -1,6 +1,8 @@
 package com.growup.pms.auth.service;
 
 import com.growup.pms.auth.dto.TokenDto;
+import com.growup.pms.common.exception.code.ErrorCode;
+import com.growup.pms.common.exception.exceptions.AuthenticationException;
 import com.growup.pms.common.security.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
@@ -10,11 +12,25 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class JwtTokenService {
     private final JwtTokenProvider tokenProvider;
+    private final RefreshTokenService refreshTokenService;
 
     public TokenDto generateJwtTokens(Long userId, Authentication authentication) {
         return TokenDto.builder()
                 .accessToken(tokenProvider.createAccessToken(userId, authentication))
                 .refreshToken(tokenProvider.createRefreshToken(userId, authentication))
                 .build();
+    }
+
+    public TokenDto refreshJwtTokens(String refreshToken) {
+        validateRefreshToken(refreshToken);
+        Long userId = tokenProvider.getUserIdFromToken(refreshToken);
+        refreshTokenService.updateRefreshToken(userId, refreshToken);
+        return generateJwtTokens(userId, tokenProvider.getAuthentication(refreshToken));
+    }
+
+    private void validateRefreshToken(String token) {
+        if (!refreshTokenService.validateToken(token)) {
+            throw new AuthenticationException(ErrorCode.INVALID_REFRESH_TOKEN_ERROR);
+        }
     }
 }

--- a/src/main/java/com/growup/pms/auth/service/RefreshTokenService.java
+++ b/src/main/java/com/growup/pms/auth/service/RefreshTokenService.java
@@ -49,12 +49,11 @@ public class RefreshTokenService {
     }
 
     private Optional<RefreshToken> getStoredRefreshToken(String token) {
-        String username = tokenProvider.getUsernameFromToken(token);
-        User user = userRepository.findByUsernameOrThrow(username);
+        User user = userRepository.findByIdOrThrow(tokenProvider.getUserIdFromToken(token));
         return refreshTokenRepository.findByUserIdAndToken(user.getId(), HashingUtil.generateHash(token));
     }
 
-    public boolean isTokenExpired(RefreshToken token) {
+    private boolean isTokenExpired(RefreshToken token) {
         return token.getExpiryDate().isBefore(Instant.now());
     }
 }

--- a/src/main/java/com/growup/pms/auth/service/RefreshTokenService.java
+++ b/src/main/java/com/growup/pms/auth/service/RefreshTokenService.java
@@ -1,0 +1,60 @@
+package com.growup.pms.auth.service;
+
+import com.growup.pms.auth.domain.RefreshToken;
+import com.growup.pms.auth.repository.RefreshTokenRepository;
+import com.growup.pms.common.security.jwt.JwtTokenProvider;
+import com.growup.pms.common.util.HashingUtil;
+import com.growup.pms.user.domain.User;
+import com.growup.pms.user.repository.UserRepository;
+import java.time.Instant;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class RefreshTokenService {
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final JwtTokenProvider tokenProvider;
+    private final UserRepository userRepository;
+
+    public void deleteTokenByUserId(Long userId) {
+        refreshTokenRepository.deleteById(userId);
+        refreshTokenRepository.flush();
+    }
+
+    public Long save(Long userId, String token) {
+        RefreshToken refreshToken = RefreshToken.builder()
+                .user(userRepository.findByIdOrThrow(userId))
+                .token(HashingUtil.generateHash(token))
+                .expiryDate(Instant.now().plusMillis(tokenProvider.refreshTokenExpirationTime))
+                .build();
+        return refreshTokenRepository.save(refreshToken).getId();
+    }
+
+    @Transactional
+    public void updateRefreshToken(Long userId, String refreshToken) {
+        deleteTokenByUserId(userId);
+        save(userId, refreshToken);
+    }
+
+    public boolean validateToken(String token) {
+        if (!tokenProvider.validateToken(token)) {
+            return false;
+        }
+
+        Optional<RefreshToken> storedRefreshToken = getStoredRefreshToken(token);
+        return storedRefreshToken.isPresent() && !isTokenExpired(storedRefreshToken.get());
+    }
+
+    private Optional<RefreshToken> getStoredRefreshToken(String token) {
+        String username = tokenProvider.getUsernameFromToken(token);
+        User user = userRepository.findByUsernameOrThrow(username);
+        return refreshTokenRepository.findByUserIdAndToken(user.getId(), HashingUtil.generateHash(token));
+    }
+
+    public boolean isTokenExpired(RefreshToken token) {
+        return token.getExpiryDate().isBefore(Instant.now());
+    }
+}

--- a/src/main/java/com/growup/pms/common/exception/code/ErrorCode.java
+++ b/src/main/java/com/growup/pms/common/exception/code/ErrorCode.java
@@ -11,6 +11,7 @@ public enum ErrorCode {
     ENTITY_ALREADY_EXIST(ErrorCategory.ENTITY_ERROR, "002", "ENTITY가 이미 존재합니다."),
 
     AUTH_AUTHENTICATION_ERROR(ErrorCategory.AUTHENTICATION_ERROR, "001", "인증을 실패했습니다."),
+    INVALID_REFRESH_TOKEN_ERROR(ErrorCategory.AUTHENTICATION_ERROR, "002", "리프레시 토큰이 유효하지 않습니다."),
 
     AUTHZ_ACCESS_DENIED(ErrorCategory.AUTHORIZATION_ERROR, "001", "접근 권한이 없습니다."),
 

--- a/src/main/java/com/growup/pms/common/util/HashingUtil.java
+++ b/src/main/java/com/growup/pms/common/util/HashingUtil.java
@@ -1,0 +1,22 @@
+package com.growup.pms.common.util;
+
+import com.growup.pms.common.exception.code.ErrorCode;
+import com.growup.pms.common.exception.exceptions.InternalServerException;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+
+public interface HashingUtil {
+    String DEFAULT_HASHING_ALGORITHM = "SHA-256";
+
+    static String generateHash(String input) {
+        try {
+            MessageDigest md = MessageDigest.getInstance(DEFAULT_HASHING_ALGORITHM);
+            byte[] hash = md.digest(input.getBytes(StandardCharsets.UTF_8));
+            return Base64.getEncoder().encodeToString(hash);
+        } catch (NoSuchAlgorithmException ex) {
+            throw new InternalServerException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+}

--- a/src/main/java/com/growup/pms/user/domain/User.java
+++ b/src/main/java/com/growup/pms/user/domain/User.java
@@ -28,7 +28,7 @@ public class User extends BaseTimeEntity {
     private Long id;
 
     @Column(nullable = false, unique = true)
-    private String username;
+    private String email;
 
     private String password;
 
@@ -46,8 +46,8 @@ public class User extends BaseTimeEntity {
     private int passwordFailureCount;
 
     @Builder
-    public User(String username, String password, Provider provider, UserProfile profile) {
-        this.username = username;
+    public User(String email, String password, Provider provider, UserProfile profile) {
+        this.email = email;
         this.password = password;
         this.provider = provider;
         this.profile = profile;

--- a/src/main/java/com/growup/pms/user/domain/UserProfile.java
+++ b/src/main/java/com/growup/pms/user/domain/UserProfile.java
@@ -19,9 +19,9 @@ public class UserProfile {
     private String image;
 
     @Builder
-    public UserProfile(String nickname, String content, String image) {
+    public UserProfile(String nickname, String bio, String image) {
         this.nickname = nickname;
-        this.bio = content;
+        this.bio = bio;
         this.image = image;
     }
 }

--- a/src/main/java/com/growup/pms/user/domain/UserProfile.java
+++ b/src/main/java/com/growup/pms/user/domain/UserProfile.java
@@ -14,14 +14,14 @@ public class UserProfile {
     @Column(nullable = false)
     private String nickname;
 
-    private String content;
+    private String bio;
 
-    private String profileImage;
+    private String image;
 
     @Builder
-    public UserProfile(String nickname, String content, String profileImage) {
+    public UserProfile(String nickname, String content, String image) {
         this.nickname = nickname;
-        this.content = content;
-        this.profileImage = profileImage;
+        this.bio = content;
+        this.image = image;
     }
 }

--- a/src/main/java/com/growup/pms/user/dto/UserCreateRequest.java
+++ b/src/main/java/com/growup/pms/user/dto/UserCreateRequest.java
@@ -17,7 +17,7 @@ import org.hibernate.validator.constraints.Length;
 @FieldMatch(first = "password", second = "passwordConfirm")
 public class UserCreateRequest {
     @Email
-    private String username;
+    private String email;
 
     @Length(min = 8, max = 20)
     private String password;
@@ -28,30 +28,30 @@ public class UserCreateRequest {
     @Length(max = 20)
     private String nickname;
 
-    private String content;
+    private String bio;
 
-    private String profileImage;
+    private String image;
 
     @Builder
-    public UserCreateRequest(String username, String password, String passwordConfirm, String nickname, String content,
-                             String profileImage) {
-        this.username = username;
+    public UserCreateRequest(String email, String password, String passwordConfirm, String nickname, String bio,
+                             String image) {
+        this.email = email;
         this.password = password;
         this.passwordConfirm = passwordConfirm;
         this.nickname = nickname;
-        this.content = content;
-        this.profileImage = profileImage;
+        this.bio = bio;
+        this.image = image;
     }
 
     public static User toEntity(UserCreateRequest request) {
         return User.builder()
-                .username(request.getUsername())
+                .email(request.getEmail())
                 .password(request.getPassword())
                 .provider(Provider.LOCAL)
                 .profile(UserProfile.builder()
                         .nickname(request.getNickname())
-                        .content(request.getContent())
-                        .profileImage(request.getProfileImage())
+                        .bio(request.getBio())
+                        .image(request.getImage())
                         .build())
                 .build();
     }

--- a/src/main/java/com/growup/pms/user/repository/UserRepository.java
+++ b/src/main/java/com/growup/pms/user/repository/UserRepository.java
@@ -8,13 +8,13 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
-    Optional<User> findByUsername(String email);
+    Optional<User> findByEmail(String email);
 
     default User findByIdOrThrow(Long id) {
         return findById(id).orElseThrow(() -> new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND));
     }
 
-    default User findByUsernameOrThrow(String username) {
-        return findByUsername(username).orElseThrow(() -> new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND));
+    default User findByEmailOrThrow(String email) {
+        return findByEmail(email).orElseThrow(() -> new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND));
     }
 }

--- a/src/main/java/com/growup/pms/user/repository/UserRepository.java
+++ b/src/main/java/com/growup/pms/user/repository/UserRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
-    Optional<User> findByUsername(String username);
+    Optional<User> findByUsername(String email);
 
     default User findByIdOrThrow(Long id) {
         return findById(id).orElseThrow(() -> new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND));

--- a/src/test/java/com/growup/pms/auth/controller/AuthenticationControllerV1Test.java
+++ b/src/test/java/com/growup/pms/auth/controller/AuthenticationControllerV1Test.java
@@ -8,14 +8,14 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.growup.pms.auth.dto.SignInRequest;
+import com.growup.pms.auth.dto.LoginRequest;
 import com.growup.pms.auth.dto.TokenDto;
 import com.growup.pms.auth.service.JwtLoginService;
 import com.growup.pms.common.exception.code.ErrorCode;
 import com.growup.pms.common.exception.exceptions.EntityNotFoundException;
 import com.growup.pms.test.CommonControllerSliceTest;
 import com.growup.pms.test.annotation.AutoKoreanDisplayName;
-import com.growup.pms.test.fixture.auth.SignInRequestFixture;
+import com.growup.pms.test.fixture.auth.LoginRequestFixture;
 import com.growup.pms.test.fixture.auth.TokenDtoFixture;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -34,13 +34,13 @@ class AuthenticationControllerV1Test extends CommonControllerSliceTest {
         @Test
         void 성공한다() throws Exception {
             // given
-            SignInRequest validRequest = SignInRequestFixture.createDefaultRequest();
+            LoginRequest validRequest = LoginRequestFixture.createDefaultRequest();
             TokenDto expectedValidToken = TokenDtoFixture.createDefaultDtoBuilder()
                     .accessToken(TokenDtoFixture.VALID_ACCESS_TOKEN)
                     .refreshToken(TokenDtoFixture.VALID_REFRESH_TOKEN)
                     .build();
 
-            when(loginService.authenticateUser(any(SignInRequest.class))).thenReturn(expectedValidToken);
+            when(loginService.authenticateUser(any(LoginRequest.class))).thenReturn(expectedValidToken);
 
             // when & then
             mockMvc.perform(post("/api/v1/auth/login")
@@ -54,9 +54,10 @@ class AuthenticationControllerV1Test extends CommonControllerSliceTest {
         @Test
         void 매치되는_정보가_없으면_예외가_발생한다() throws Exception {
             // given
-            SignInRequest badRequest = SignInRequestFixture.createDefaultRequest();
+            LoginRequest badRequest = LoginRequestFixture.createDefaultRequest();
 
-            doThrow(new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND)).when(loginService).authenticateUser(any(SignInRequest.class));
+            doThrow(new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND)).when(loginService).authenticateUser(any(
+                    LoginRequest.class));
 
             // when & then
             mockMvc.perform(post("/api/v1/auth/login")

--- a/src/test/java/com/growup/pms/auth/controller/LoginControllerV1Test.java
+++ b/src/test/java/com/growup/pms/auth/controller/LoginControllerV1Test.java
@@ -24,7 +24,7 @@ import org.springframework.http.MediaType;
 
 @AutoKoreanDisplayName
 @SuppressWarnings("NonAsciiCharacters")
-class AuthenticationControllerV1Test extends CommonControllerSliceTest {
+class LoginControllerV1Test extends CommonControllerSliceTest {
     @Autowired
     private JwtLoginService loginService;
 

--- a/src/test/java/com/growup/pms/auth/controller/LoginControllerV1Test.java
+++ b/src/test/java/com/growup/pms/auth/controller/LoginControllerV1Test.java
@@ -43,12 +43,12 @@ class LoginControllerV1Test extends CommonControllerSliceTest {
             when(loginService.authenticateUser(any(LoginRequest.class))).thenReturn(expectedValidToken);
 
             // when & then
-            mockMvc.perform(post("/api/v1/auth/login")
+            mockMvc.perform(post("/api/v1/user/login")
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(validRequest)))
                     .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.access_token").value(TokenDtoFixture.VALID_ACCESS_TOKEN))
-                    .andExpect(cookie().value("refresh_token", TokenDtoFixture.VALID_REFRESH_TOKEN));
+                    .andExpect(jsonPath("$.accessToken").value(TokenDtoFixture.VALID_ACCESS_TOKEN))
+                    .andExpect(cookie().value("refreshToken", TokenDtoFixture.VALID_REFRESH_TOKEN));
         }
 
         @Test
@@ -60,12 +60,12 @@ class LoginControllerV1Test extends CommonControllerSliceTest {
                     LoginRequest.class));
 
             // when & then
-            mockMvc.perform(post("/api/v1/auth/login")
+            mockMvc.perform(post("/api/v1/user/login")
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(badRequest)))
                     .andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.access_token").doesNotExist())
-                    .andExpect(cookie().doesNotExist("refresh_token"));
+                    .andExpect(jsonPath("$.accessToken").doesNotExist())
+                    .andExpect(cookie().doesNotExist("refreshToken"));
         }
     }
 }

--- a/src/test/java/com/growup/pms/auth/service/JwtLoginServiceTest.java
+++ b/src/test/java/com/growup/pms/auth/service/JwtLoginServiceTest.java
@@ -59,7 +59,7 @@ class JwtLoginServiceTest {
             // given
             Long userId = 1L;
             LoginRequest validRequest = LoginRequestFixture.createDefaultRequest();
-            UsernamePasswordAuthenticationToken token = new UsernamePasswordAuthenticationToken(validRequest.getUsername(), validRequest.getPassword());
+            UsernamePasswordAuthenticationToken token = new UsernamePasswordAuthenticationToken(validRequest.getEmail(), validRequest.getPassword());
             TokenDto expectedToken = TokenDtoFixture.createDefaultDto();
 
             when(authenticationManager.authenticate(token)).thenReturn(authentication);
@@ -83,7 +83,7 @@ class JwtLoginServiceTest {
         void 실패하면_예외가_발생한다() {
             // given
             LoginRequest badRequest = LoginRequestFixture.createDefaultRequest();
-            UsernamePasswordAuthenticationToken token = new UsernamePasswordAuthenticationToken(badRequest.getUsername(), badRequest.getPassword());
+            UsernamePasswordAuthenticationToken token = new UsernamePasswordAuthenticationToken(badRequest.getEmail(), badRequest.getPassword());
 
             doThrow(new RuntimeException()).when(authenticationManager).authenticate(token);
 

--- a/src/test/java/com/growup/pms/auth/service/JwtLoginServiceTest.java
+++ b/src/test/java/com/growup/pms/auth/service/JwtLoginServiceTest.java
@@ -7,10 +7,10 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.growup.pms.auth.domain.SecurityUser;
-import com.growup.pms.auth.dto.SignInRequest;
+import com.growup.pms.auth.dto.LoginRequest;
 import com.growup.pms.auth.dto.TokenDto;
 import com.growup.pms.test.annotation.AutoKoreanDisplayName;
-import com.growup.pms.test.fixture.auth.SignInRequestFixture;
+import com.growup.pms.test.fixture.auth.LoginRequestFixture;
 import com.growup.pms.test.fixture.auth.TokenDtoFixture;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -58,7 +58,7 @@ class JwtLoginServiceTest {
         void 성공한다() {
             // given
             Long userId = 1L;
-            SignInRequest validRequest = SignInRequestFixture.createDefaultRequest();
+            LoginRequest validRequest = LoginRequestFixture.createDefaultRequest();
             UsernamePasswordAuthenticationToken token = new UsernamePasswordAuthenticationToken(validRequest.getUsername(), validRequest.getPassword());
             TokenDto expectedToken = TokenDtoFixture.createDefaultDto();
 
@@ -82,7 +82,7 @@ class JwtLoginServiceTest {
         @Test
         void 실패하면_예외가_발생한다() {
             // given
-            SignInRequest badRequest = SignInRequestFixture.createDefaultRequest();
+            LoginRequest badRequest = LoginRequestFixture.createDefaultRequest();
             UsernamePasswordAuthenticationToken token = new UsernamePasswordAuthenticationToken(badRequest.getUsername(), badRequest.getPassword());
 
             doThrow(new RuntimeException()).when(authenticationManager).authenticate(token);

--- a/src/test/java/com/growup/pms/auth/service/JwtTokenServiceTest.java
+++ b/src/test/java/com/growup/pms/auth/service/JwtTokenServiceTest.java
@@ -33,7 +33,7 @@ class JwtTokenServiceTest {
     void 토큰을_새롭게_생성한다() {
         // given
         Authentication authentication = new UsernamePasswordAuthenticationToken(
-                UserFixture.DEFAULT_USERNAME, UserFixture.DEFAULT_PASSWORD, Collections.emptyList());
+                UserFixture.DEFAULT_EMAIL, UserFixture.DEFAULT_PASSWORD, Collections.emptyList());
         TokenDto expectedTokenDto = TokenDtoFixture.createDefaultDtoBuilder()
                         .accessToken(TokenDtoFixture.NEW_ACCESS_TOKEN)
                         .refreshToken(TokenDtoFixture.NEW_REFRESH_TOKEN)

--- a/src/test/java/com/growup/pms/auth/service/RefreshTokenServiceTest.java
+++ b/src/test/java/com/growup/pms/auth/service/RefreshTokenServiceTest.java
@@ -1,0 +1,173 @@
+package com.growup.pms.auth.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.growup.pms.auth.domain.RefreshToken;
+import com.growup.pms.auth.repository.RefreshTokenRepository;
+import com.growup.pms.common.exception.exceptions.EntityNotFoundException;
+import com.growup.pms.common.security.jwt.JwtTokenProvider;
+import com.growup.pms.test.annotation.AutoKoreanDisplayName;
+import com.growup.pms.test.fixture.auth.RefreshTokenFixture;
+import com.growup.pms.test.fixture.user.UserFixture;
+import com.growup.pms.user.domain.User;
+import com.growup.pms.user.repository.UserRepository;
+import java.time.Instant;
+import java.util.Optional;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@AutoKoreanDisplayName
+@SuppressWarnings("NonAsciiCharacters")
+@ExtendWith(MockitoExtension.class)
+class RefreshTokenServiceTest {
+    @Mock
+    RefreshTokenRepository refreshTokenRepository;
+
+    @Mock
+    JwtTokenProvider tokenProvider;
+
+    @Mock
+    UserRepository userRepository;
+
+    @InjectMocks
+    RefreshTokenService refreshTokenService;
+
+    @Nested
+    class 리프레시_토큰을_저장_시에 {
+
+        @Test
+        void 성공한다() {
+            // given
+            Long expectedId = 1L;
+            User user = UserFixture.createUserWithId(1L);
+            RefreshToken validRefreshToken = RefreshTokenFixture.createRefreshTokenWithUser(user);
+
+            when(refreshTokenRepository.save(any(RefreshToken.class))).thenReturn(validRefreshToken);
+
+            // when
+            Long actualId = refreshTokenService.save(user.getId(), validRefreshToken.getToken());
+
+            // then
+            assertThat(actualId).isEqualTo(expectedId);
+
+            verify(refreshTokenRepository).save(any(RefreshToken.class));
+        }
+
+        @Test
+        void 존재하지_않는_유저일_경우_예외가_발생한다() {
+            // given
+            Long userId = 1L;
+            User user = UserFixture.createUserWithId(userId);
+
+            doThrow(EntityNotFoundException.class).when(userRepository).findByIdOrThrow(user.getId());
+
+            // when & then
+            assertThatThrownBy(() -> refreshTokenService.save(userId, RefreshTokenFixture.VALID_REFRESH_TOKEN))
+                    .isInstanceOf(EntityNotFoundException.class);
+        }
+    }
+
+    @Nested
+    class 리프레시_토큰을_제거_시에 {
+
+        @Test
+        void 성공한다() {
+            // given
+            User user = UserFixture.createUserWithId(1L);
+
+            // when
+            refreshTokenService.deleteTokenByUserId(user.getId());
+
+            // then
+            verify(refreshTokenRepository).deleteById(user.getId());
+            verify(refreshTokenRepository).flush();
+        }
+    }
+
+    @Nested
+    class 리프레시_토큰을_검증_시에 {
+
+        @Test
+        void 성공한다() {
+            // given
+            Long userId = 1L;
+            User user = UserFixture.createUserWithId(userId);
+            Instant validExpiryDate = Instant.now().plusMillis(1000);
+            RefreshToken validRefreshToken = RefreshTokenFixture.createRefreshTokenWithUserAndExpiryDate(user, validExpiryDate);
+
+            when(tokenProvider.validateToken(validRefreshToken.getToken())).thenReturn(true);
+            when(tokenProvider.getUserIdFromToken(validRefreshToken.getToken())).thenReturn(userId);
+            when(userRepository.findByIdOrThrow(userId)).thenReturn(user);
+            when(refreshTokenRepository.findByUserIdAndToken(eq(userId), any(String.class))).thenReturn(Optional.of(validRefreshToken));
+
+            // when
+            boolean actualResult = refreshTokenService.validateToken(validRefreshToken.getToken());
+
+            // then
+            assertThat(actualResult).isTrue();
+        }
+
+        @Test
+        void 토큰_검증에_실패하면_실패한다() {
+            // given
+            String invalidToken = RefreshTokenFixture.INVALID_REFRESH_TOKEN;
+
+            when(tokenProvider.validateToken(invalidToken)).thenReturn(false);
+
+            // when
+            boolean actualResult = refreshTokenService.validateToken(invalidToken);
+
+            // then
+            assertThat(actualResult).isFalse();
+        }
+
+        @Test
+        void DB에_해당_토큰이_없을_경우_실패한다() {
+            // given
+            Long userId = 1L;
+            User user = UserFixture.createUserWithId(userId);
+            String validRefreshToken = RefreshTokenFixture.VALID_REFRESH_TOKEN;
+
+            when(tokenProvider.validateToken(validRefreshToken)).thenReturn(true);
+            when(tokenProvider.getUserIdFromToken(validRefreshToken)).thenReturn(userId);
+            when(userRepository.findByIdOrThrow(userId)).thenReturn(user);
+            when(refreshTokenRepository.findByUserIdAndToken(eq(userId), any(String.class))).thenReturn(Optional.empty());
+
+            // when
+            boolean actualResult = refreshTokenService.validateToken(validRefreshToken);
+
+            // then
+            assertThat(actualResult).isFalse();
+        }
+
+        @Test
+        void 토큰이_만료된_경우_실패한다() {
+            // given
+            Long userId = 1L;
+            User user = UserFixture.createUserWithId(userId);
+            Instant expiredExpiryDate = Instant.now().minusMillis(1000);
+            RefreshToken expiredRefreshToken = RefreshTokenFixture.createRefreshTokenWithUserAndExpiryDate(user, expiredExpiryDate);
+
+            when(tokenProvider.validateToken(expiredRefreshToken.getToken())).thenReturn(true);
+            when(tokenProvider.getUserIdFromToken(expiredRefreshToken.getToken())).thenReturn(userId);
+            when(userRepository.findByIdOrThrow(userId)).thenReturn(user);
+            when(refreshTokenRepository.findByUserIdAndToken(eq(userId), any(String.class))).thenReturn(Optional.of(expiredRefreshToken));
+
+            // when
+            boolean actualResult = refreshTokenService.validateToken(expiredRefreshToken.getToken());
+
+            // then
+            assertThat(actualResult).isFalse();
+        }
+    }
+}

--- a/src/test/java/com/growup/pms/test/CommonControllerSliceTest.java
+++ b/src/test/java/com/growup/pms/test/CommonControllerSliceTest.java
@@ -3,12 +3,16 @@ package com.growup.pms.test;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.growup.pms.common.security.jwt.JwtTokenProvider;
 import com.growup.pms.test.annotation.AutoServiceMockBeans;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.ComponentScan.Filter;
 import org.springframework.context.annotation.FilterType;
+import org.springframework.stereotype.Service;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.bind.annotation.RestController;
@@ -23,6 +27,9 @@ public abstract class CommonControllerSliceTest {
     @Autowired
     protected ObjectMapper objectMapper;
 
+    @Autowired
+    private ConfigurableListableBeanFactory beanFactory;
+
     @MockBean
     protected JwtTokenProvider jwtTokenProvider;
 
@@ -30,5 +37,16 @@ public abstract class CommonControllerSliceTest {
     void setUpEach(WebApplicationContext context) {
         this.mockMvc = MockMvcBuilders.webAppContextSetup(context)
                 .build();
+    }
+
+    @AfterEach
+    void resetMocks() {
+        String[] mockBeanNames = beanFactory.getBeanNamesForAnnotation(Service.class);
+        for (String beanName : mockBeanNames) {
+            Object bean = beanFactory.getBean(beanName);
+            if (Mockito.mockingDetails(bean).isMock()) {
+                Mockito.reset(bean);
+            }
+        }
     }
 }

--- a/src/test/java/com/growup/pms/test/fixture/auth/LoginRequestFixture.java
+++ b/src/test/java/com/growup/pms/test/fixture/auth/LoginRequestFixture.java
@@ -1,7 +1,7 @@
 package com.growup.pms.test.fixture.auth;
 
 import static com.growup.pms.test.fixture.user.UserFixture.DEFAULT_PASSWORD;
-import static com.growup.pms.test.fixture.user.UserFixture.DEFAULT_USERNAME;
+import static com.growup.pms.test.fixture.user.UserFixture.DEFAULT_EMAIL;
 
 import com.growup.pms.auth.dto.LoginRequest;
 
@@ -13,7 +13,7 @@ public class LoginRequestFixture {
 
     public static LoginRequest.LoginRequestBuilder createDefaultRequestBuilder() {
         return LoginRequest.builder()
-                .username(DEFAULT_USERNAME)
+                .email(DEFAULT_EMAIL)
                 .password(DEFAULT_PASSWORD);
     }
 }

--- a/src/test/java/com/growup/pms/test/fixture/auth/LoginRequestFixture.java
+++ b/src/test/java/com/growup/pms/test/fixture/auth/LoginRequestFixture.java
@@ -3,16 +3,16 @@ package com.growup.pms.test.fixture.auth;
 import static com.growup.pms.test.fixture.user.UserFixture.DEFAULT_PASSWORD;
 import static com.growup.pms.test.fixture.user.UserFixture.DEFAULT_USERNAME;
 
-import com.growup.pms.auth.dto.SignInRequest;
+import com.growup.pms.auth.dto.LoginRequest;
 
-public class SignInRequestFixture {
+public class LoginRequestFixture {
 
-    public static SignInRequest createDefaultRequest() {
+    public static LoginRequest createDefaultRequest() {
         return createDefaultRequestBuilder().build();
     }
 
-    public static SignInRequest.SignInRequestBuilder createDefaultRequestBuilder() {
-        return SignInRequest.builder()
+    public static LoginRequest.LoginRequestBuilder createDefaultRequestBuilder() {
+        return LoginRequest.builder()
                 .username(DEFAULT_USERNAME)
                 .password(DEFAULT_PASSWORD);
     }

--- a/src/test/java/com/growup/pms/test/fixture/auth/RefreshTokenFixture.java
+++ b/src/test/java/com/growup/pms/test/fixture/auth/RefreshTokenFixture.java
@@ -1,0 +1,37 @@
+package com.growup.pms.test.fixture.auth;
+
+import com.growup.pms.auth.domain.RefreshToken;
+import com.growup.pms.user.domain.User;
+import java.time.Instant;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class RefreshTokenFixture {
+    public static final Long DEFAULT_REFRESH_TOKEN_ID = 1L;
+
+    public static final String VALID_REFRESH_TOKEN = "validRefreshToken";
+    public static final String INVALID_REFRESH_TOKEN = "invalidRefreshToken";
+
+    public static final Instant VALID_EXPIRY_DATE = Instant.now().plusMillis(1000);
+    public static final Instant INVALID_EXPIRY_DATE = Instant.now().minusMillis(1000);
+
+    public static RefreshToken createRefreshTokenWithUser(User user) {
+        RefreshToken refreshToken = createDefaultTokenBuilder().user(user)
+                .build();
+        ReflectionTestUtils.setField(refreshToken, "id", DEFAULT_REFRESH_TOKEN_ID);
+        return refreshToken;
+    }
+
+    public static RefreshToken createRefreshTokenWithUserAndExpiryDate(User user, Instant expiryDate) {
+        RefreshToken refreshToken = createDefaultTokenBuilder().user(user)
+                .expiryDate(expiryDate)
+                .build();
+        ReflectionTestUtils.setField(refreshToken, "id", DEFAULT_REFRESH_TOKEN_ID);
+        return refreshToken;
+    }
+
+    public static RefreshToken.RefreshTokenBuilder createDefaultTokenBuilder() {
+        return RefreshToken.builder()
+                .token(VALID_REFRESH_TOKEN)
+                .expiryDate(VALID_EXPIRY_DATE);
+    }
+}

--- a/src/test/java/com/growup/pms/test/fixture/user/UserCreateRequestFixture.java
+++ b/src/test/java/com/growup/pms/test/fixture/user/UserCreateRequestFixture.java
@@ -13,12 +13,12 @@ public class UserCreateRequestFixture {
 
     public static UserCreateRequest createRequestFromUser(User user) {
         return UserCreateRequest.builder()
-                .username(user.getUsername())
+                .username(user.getEmail())
                 .password(user.getPassword())
                 .passwordConfirm(user.getPassword())
                 .nickname(user.getProfile().getNickname())
-                .content(user.getProfile().getContent())
-                .profileImage(user.getProfile().getProfileImage())
+                .content(user.getProfile().getBio())
+                .profileImage(user.getProfile().getImage())
                 .build();
     }
 

--- a/src/test/java/com/growup/pms/test/fixture/user/UserCreateRequestFixture.java
+++ b/src/test/java/com/growup/pms/test/fixture/user/UserCreateRequestFixture.java
@@ -13,22 +13,22 @@ public class UserCreateRequestFixture {
 
     public static UserCreateRequest createRequestFromUser(User user) {
         return UserCreateRequest.builder()
-                .username(user.getEmail())
+                .email(user.getEmail())
                 .password(user.getPassword())
                 .passwordConfirm(user.getPassword())
                 .nickname(user.getProfile().getNickname())
-                .content(user.getProfile().getBio())
-                .profileImage(user.getProfile().getImage())
+                .bio(user.getProfile().getBio())
+                .image(user.getProfile().getImage())
                 .build();
     }
 
     public static UserCreateRequest.UserCreateRequestBuilder createDefaultRequestBuilder() {
         return UserCreateRequest.builder()
-                .username(DEFAULT_USERNAME)
+                .email(DEFAULT_EMAIL)
                 .password(DEFAULT_PASSWORD)
                 .passwordConfirm(DEFAULT_PASSWORD)
                 .nickname(DEFAULT_NICKNAME)
-                .content(DEFAULT_CONTENT)
-                .profileImage(DEFAULT_PROFILE_IMAGE);
+                .bio(DEFAULT_BIO)
+                .image(DEFAULT_IMAGE);
     }
 }

--- a/src/test/java/com/growup/pms/test/fixture/user/UserFixture.java
+++ b/src/test/java/com/growup/pms/test/fixture/user/UserFixture.java
@@ -6,13 +6,13 @@ import com.growup.pms.user.domain.UserProfile;
 import org.springframework.test.util.ReflectionTestUtils;
 
 public class UserFixture {
-    public static final String DEFAULT_USERNAME = "ryan@example.com";
+    public static final String DEFAULT_EMAIL = "ryan@example.com";
     public static final String DEFAULT_PASSWORD = "!test1234";
     public static final String DEFAULT_NICKNAME = "라이언";
-    public static final String DEFAULT_CONTENT = "안녕하세요, 라이언입니다!";
-    public static final String DEFAULT_PROFILE_IMAGE = "https://example.com/profile/ryan.jpg";
+    public static final String DEFAULT_BIO = "안녕하세요, 라이언입니다!";
+    public static final String DEFAULT_IMAGE = "https://example.com/profile/ryan.jpg";
 
-    public static final String INVALID_USERNAME = "ryan";
+    public static final String INVALID_EMAIL = "ryan";
     public static final String INVALID_PASSWORD = "!test";
     public static final String INVALID_NICKNAME = " ";
 
@@ -24,13 +24,13 @@ public class UserFixture {
 
     public static User.UserBuilder createDefaultUserBuilder() {
         return User.builder()
-                .username(DEFAULT_USERNAME)
+                .email(DEFAULT_EMAIL)
                 .password(DEFAULT_PASSWORD)
                 .provider(Provider.LOCAL)
                 .profile(UserProfile.builder()
                         .nickname(DEFAULT_NICKNAME)
-                        .content(DEFAULT_CONTENT)
-                        .profileImage(DEFAULT_PROFILE_IMAGE)
+                        .bio(DEFAULT_BIO)
+                        .image(DEFAULT_IMAGE)
                         .build());
     }
 }


### PR DESCRIPTION
## PR Type

- [x] **\[Feat\]** 🎨 새로운 기능을 추가했어요.
- [x] **\[Test\]** 🧪 테스트 코드를 추가/삭제/변경 했어요.
- [x] **\[Rename\]** 📁 폴더 및 파일의 이름을 변경했어요.

## Related Issues

- close #45 

## What does this PR do?

<!--무엇을 하셨나요?-->

- [x] 통일성과 일관성을 위해 작성된 API 명세에 맞춰서 백엔드와 프론트엔드 간의 이름을 일치시킴
- [x] 토큰을 재발급하는 로직을 추가함

## Other information

- 프론트 API 명세에 맞춰서 자잘한 이름 변경이 많아서 변경된 라인 수는 많은데 실질적으로 추가된 라인은 별로 없습니다 😿
- 새로운 이슈를 작성해서 추가 브랜치에서 액세스 토큰을 바디가 아닌 헤더로 내보내도록 수정하겠습니다!

## Screenshots
![image](https://github.com/GU-99/grow-up-pms/assets/8318212/ea8e8fba-a8e8-4cad-9230-3a9a249e88bb)
