### PR TITLE
Feat: #39 팀 CRUD API를 구현함

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,7 @@ dependencies {
     compileOnly 'io.jsonwebtoken:jjwt-api:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+    implementation 'org.openapitools:jackson-databind-nullable:0.2.6'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/growup/pms/common/config/ObjectMapperConfig.java
+++ b/src/main/java/com/growup/pms/common/config/ObjectMapperConfig.java
@@ -1,0 +1,31 @@
+package com.growup.pms.common.config;
+
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import org.openapitools.jackson.nullable.JsonNullableModule;
+import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+@Configuration
+public class ObjectMapperConfig {
+
+    @Bean
+    @Primary
+    public Jackson2ObjectMapperBuilderCustomizer jackson2ObjectMapperBuilderCustomizer() {
+        return builder -> {
+            builder.serializationInclusion(Include.ALWAYS);
+            builder.featuresToDisable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+            builder.featuresToDisable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
+            builder.featuresToDisable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+            builder.modules(jsonNullableModule());
+        };
+    }
+
+    @Bean
+    public JsonNullableModule jsonNullableModule() {
+        return new JsonNullableModule();
+    }
+}

--- a/src/main/java/com/growup/pms/common/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/growup/pms/common/exception/handler/GlobalExceptionHandler.java
@@ -21,7 +21,14 @@ import org.springframework.web.method.annotation.MethodArgumentTypeMismatchExcep
 public class GlobalExceptionHandler {
     private static final String LOG_MESSAGE_FORMAT = "[{}] ({} {}) {}";
 
-    @ExceptionHandler({EntityNotFoundException.class, DuplicateException.class})
+    @ExceptionHandler(EntityNotFoundException.class)
+    protected ResponseEntity<ErrorResponse> handleNotFoundException(BusinessException ex, HttpServletRequest request) {
+        logInfo(ex, request);
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(ErrorResponse.of(ex.getErrorCode()));
+    }
+
+    @ExceptionHandler(DuplicateException.class)
     protected ResponseEntity<ErrorResponse> handleBadRequestException(BusinessException ex, HttpServletRequest request) {
         logInfo(ex, request);
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)

--- a/src/main/java/com/growup/pms/team/controller/TeamControllerV1.java
+++ b/src/main/java/com/growup/pms/team/controller/TeamControllerV1.java
@@ -1,5 +1,6 @@
 package com.growup.pms.team.controller;
 
+import com.growup.pms.auth.domain.SecurityUser;
 import com.growup.pms.team.dto.TeamCreateRequest;
 import com.growup.pms.team.dto.TeamResponse;
 import com.growup.pms.team.dto.TeamUpdateRequest;
@@ -8,6 +9,7 @@ import jakarta.validation.Valid;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -31,8 +33,8 @@ public class TeamControllerV1 {
     }
 
     @PostMapping
-    public ResponseEntity<Void> createTeam(@Valid @RequestBody TeamCreateRequest request) {
-        return ResponseEntity.created(URI.create("/api/v1/team/" + teamService.createTeam(request)))
+    public ResponseEntity<Void> createTeam(@AuthenticationPrincipal SecurityUser user, @Valid @RequestBody TeamCreateRequest request) {
+        return ResponseEntity.created(URI.create("/api/v1/team/" + teamService.createTeam(user.getId(), request)))
                 .build();
     }
 

--- a/src/main/java/com/growup/pms/team/controller/TeamControllerV1.java
+++ b/src/main/java/com/growup/pms/team/controller/TeamControllerV1.java
@@ -1,0 +1,41 @@
+package com.growup.pms.team.controller;
+
+import com.growup.pms.team.dto.TeamCreateRequest;
+import com.growup.pms.team.dto.TeamResponse;
+import com.growup.pms.team.service.TeamService;
+import jakarta.validation.Valid;
+import java.net.URI;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/team")
+public class TeamControllerV1 {
+    private final TeamService teamService;
+
+    @GetMapping("/{teamId}")
+    public ResponseEntity<TeamResponse> getTeam(@PathVariable Long teamId) {
+        return ResponseEntity.ok()
+                .body(teamService.getTeam(teamId));
+    }
+
+    @PostMapping
+    public ResponseEntity<Void> createTeam(@Valid @RequestBody TeamCreateRequest request) {
+        return ResponseEntity.created(URI.create("/api/v1/team/" + teamService.createTeam(request)))
+                .build();
+    }
+
+    @DeleteMapping("/{teamId}")
+    public ResponseEntity<Void> deleteTeam(@PathVariable Long teamId) {
+        teamService.deleteTeam(teamId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/growup/pms/team/controller/TeamControllerV1.java
+++ b/src/main/java/com/growup/pms/team/controller/TeamControllerV1.java
@@ -20,6 +20,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/team")
+// TODO: 향후 권한 인가가 구현되면 각 요청이 올바른 사용자로부터 온 요청인지 검사해야 함
 public class TeamControllerV1 {
     private final TeamService teamService;
 

--- a/src/main/java/com/growup/pms/team/controller/TeamControllerV1.java
+++ b/src/main/java/com/growup/pms/team/controller/TeamControllerV1.java
@@ -2,6 +2,7 @@ package com.growup.pms.team.controller;
 
 import com.growup.pms.team.dto.TeamCreateRequest;
 import com.growup.pms.team.dto.TeamResponse;
+import com.growup.pms.team.dto.TeamUpdateRequest;
 import com.growup.pms.team.service.TeamService;
 import jakarta.validation.Valid;
 import java.net.URI;
@@ -9,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -36,6 +38,12 @@ public class TeamControllerV1 {
     @DeleteMapping("/{teamId}")
     public ResponseEntity<Void> deleteTeam(@PathVariable Long teamId) {
         teamService.deleteTeam(teamId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PatchMapping("/{teamId}")
+    public ResponseEntity<Void> updateTeam(@PathVariable Long teamId, @Valid @RequestBody TeamUpdateRequest request) {
+        teamService.updateTeam(teamId, request);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/growup/pms/team/domain/Team.java
+++ b/src/main/java/com/growup/pms/team/domain/Team.java
@@ -1,12 +1,17 @@
 package com.growup.pms.team.domain;
 
 import com.growup.pms.common.BaseTimeEntity;
+import com.growup.pms.user.domain.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,7 +19,7 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@Table(name = "teams")
+@Table(name = "teams", uniqueConstraints = @UniqueConstraint(columnNames = {"creator_id", "name"}))
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Team extends BaseTimeEntity {
     @Id
@@ -22,12 +27,18 @@ public class Team extends BaseTimeEntity {
     @Column(name = "team_id")
     private Long id;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "creator_id", updatable = false, nullable = false)
+    private User creator;
+
+    @Column(nullable = false)
     private String name;
 
     private String content;
 
     @Builder
-    public Team(String name, String content) {
+    public Team(User creator, String name, String content) {
+        this.creator = creator;
         this.name = name;
         this.content = content;
     }

--- a/src/main/java/com/growup/pms/team/domain/Team.java
+++ b/src/main/java/com/growup/pms/team/domain/Team.java
@@ -42,4 +42,12 @@ public class Team extends BaseTimeEntity {
         this.name = name;
         this.content = content;
     }
+
+    public void updateName(String newName) {
+        this.name = newName;
+    }
+
+    public void updateContent(String newContent) {
+        this.content = newContent;
+    }
 }

--- a/src/main/java/com/growup/pms/team/dto/TeamCreateRequest.java
+++ b/src/main/java/com/growup/pms/team/dto/TeamCreateRequest.java
@@ -1,0 +1,39 @@
+package com.growup.pms.team.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.growup.pms.team.domain.Team;
+import com.growup.pms.user.domain.User;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class TeamCreateRequest {
+    @Pattern(regexp = "^[가-힣a-zA-Z0-9]{1,10}$", message = "팀 이름은 한글, 영문, 숫자로 구성된 1~10자리여야 합니다.")
+    private String name;
+
+    private String content;
+
+    @NotNull
+    @JsonProperty("creator")
+    private Long creatorId;
+
+    @Builder
+    public TeamCreateRequest(String name, String content, Long creatorId) {
+        this.name = name;
+        this.content = content;
+        this.creatorId = creatorId;
+    }
+
+    public static Team toEntity(TeamCreateRequest request, User creator) {
+        return Team.builder()
+                .name(request.getName())
+                .content(request.getContent())
+                .creator(creator)
+                .build();
+    }
+}

--- a/src/main/java/com/growup/pms/team/dto/TeamCreateRequest.java
+++ b/src/main/java/com/growup/pms/team/dto/TeamCreateRequest.java
@@ -19,15 +19,10 @@ public class TeamCreateRequest {
 
     private String content;
 
-    @NotNull
-    @JsonProperty("creator")
-    private Long creatorId;
-
     @Builder
-    public TeamCreateRequest(String name, String content, Long creatorId) {
+    public TeamCreateRequest(String name, String content) {
         this.name = name;
         this.content = content;
-        this.creatorId = creatorId;
     }
 
     public static Team toEntity(TeamCreateRequest request, User creator) {

--- a/src/main/java/com/growup/pms/team/dto/TeamCreateRequest.java
+++ b/src/main/java/com/growup/pms/team/dto/TeamCreateRequest.java
@@ -1,9 +1,7 @@
 package com.growup.pms.team.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.growup.pms.team.domain.Team;
 import com.growup.pms.user.domain.User;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import lombok.AccessLevel;
 import lombok.Builder;

--- a/src/main/java/com/growup/pms/team/dto/TeamCreateRequest.java
+++ b/src/main/java/com/growup/pms/team/dto/TeamCreateRequest.java
@@ -12,6 +12,7 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
+// TODO: 역할이나 권한이 구현되면 API 명세에 있는 coworker 필드를 추가해야 함
 public class TeamCreateRequest {
     @Pattern(regexp = "^[가-힣a-zA-Z0-9]{1,10}$", message = "팀 이름은 한글, 영문, 숫자로 구성된 1~10자리여야 합니다.")
     private String name;

--- a/src/main/java/com/growup/pms/team/dto/TeamResponse.java
+++ b/src/main/java/com/growup/pms/team/dto/TeamResponse.java
@@ -1,0 +1,27 @@
+package com.growup.pms.team.dto;
+
+import com.growup.pms.team.domain.Team;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class TeamResponse {
+    private String name;
+    private String content;
+
+    @Builder
+    public TeamResponse(String name, String content) {
+        this.name = name;
+        this.content = content;
+    }
+
+    public static TeamResponse from(Team team) {
+        return TeamResponse.builder()
+                .name(team.getName())
+                .content(team.getContent())
+                .build();
+    }
+}

--- a/src/main/java/com/growup/pms/team/dto/TeamUpdateRequest.java
+++ b/src/main/java/com/growup/pms/team/dto/TeamUpdateRequest.java
@@ -1,0 +1,23 @@
+package com.growup.pms.team.dto;
+
+import jakarta.validation.constraints.Pattern;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.openapitools.jackson.nullable.JsonNullable;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class TeamUpdateRequest {
+    @Pattern(regexp = "^[가-힣a-zA-Z0-9]{1,10}$", message = "팀 이름은 한글, 영문, 숫자로 구성된 1~10자리여야 합니다.")
+    private JsonNullable<String> name = JsonNullable.undefined();
+
+    private JsonNullable<String> content = JsonNullable.undefined();
+
+    @Builder
+    public TeamUpdateRequest(JsonNullable<String> name, JsonNullable<String> content) {
+        this.name = name;
+        this.content = content;
+    }
+}

--- a/src/main/java/com/growup/pms/team/repository/TeamRepository.java
+++ b/src/main/java/com/growup/pms/team/repository/TeamRepository.java
@@ -1,0 +1,13 @@
+package com.growup.pms.team.repository;
+
+import com.growup.pms.common.exception.code.ErrorCode;
+import com.growup.pms.common.exception.exceptions.EntityNotFoundException;
+import com.growup.pms.team.domain.Team;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TeamRepository extends JpaRepository<Team, Long> {
+
+    default Team findByIdOrThrow(Long id) {
+        return findById(id).orElseThrow(() -> new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/growup/pms/team/service/TeamService.java
+++ b/src/main/java/com/growup/pms/team/service/TeamService.java
@@ -21,8 +21,8 @@ public class TeamService {
     }
 
     // TODO: 권한이나 역할이 구현되면 팀 생성 시 coworker 필드에 있는 팀원들을 팀 멤버 테이블에 추가해야 함
-    public Long createTeam(TeamCreateRequest request) {
-        return teamRepository.save(TeamCreateRequest.toEntity(request, userRepository.findByIdOrThrow(request.getCreatorId())))
+    public Long createTeam(Long creatorId, TeamCreateRequest request) {
+        return teamRepository.save(TeamCreateRequest.toEntity(request, userRepository.findByIdOrThrow(creatorId)))
                 .getId();
     }
 

--- a/src/main/java/com/growup/pms/team/service/TeamService.java
+++ b/src/main/java/com/growup/pms/team/service/TeamService.java
@@ -19,6 +19,7 @@ public class TeamService {
         return TeamResponse.from(teamRepository.findByIdOrThrow(teamId));
     }
 
+    // TODO: 권한이나 역할이 구현되면 팀 생성 시 coworker 필드에 있는 팀원들을 팀 멤버 테이블에 추가해야 함
     public Long createTeam(TeamCreateRequest request) {
         return teamRepository.save(TeamCreateRequest.toEntity(request, userRepository.findByIdOrThrow(request.getCreatorId())))
                 .getId();

--- a/src/main/java/com/growup/pms/team/service/TeamService.java
+++ b/src/main/java/com/growup/pms/team/service/TeamService.java
@@ -1,7 +1,9 @@
 package com.growup.pms.team.service;
 
+import com.growup.pms.team.domain.Team;
 import com.growup.pms.team.dto.TeamCreateRequest;
 import com.growup.pms.team.dto.TeamResponse;
+import com.growup.pms.team.dto.TeamUpdateRequest;
 import com.growup.pms.team.repository.TeamRepository;
 import com.growup.pms.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -24,5 +26,16 @@ public class TeamService {
 
     public void deleteTeam(Long teamId) {
         teamRepository.deleteById(teamId);
+    }
+
+    public void updateTeam(Long teamId, TeamUpdateRequest request) {
+        Team team = teamRepository.findByIdOrThrow(teamId);
+        if (request.getName().isPresent()) {
+            team.updateName(request.getName().get());
+        }
+        if (request.getContent().isPresent()) {
+            team.updateContent(request.getContent().get());
+        }
+        teamRepository.save(team);
     }
 }

--- a/src/main/java/com/growup/pms/team/service/TeamService.java
+++ b/src/main/java/com/growup/pms/team/service/TeamService.java
@@ -1,0 +1,28 @@
+package com.growup.pms.team.service;
+
+import com.growup.pms.team.dto.TeamCreateRequest;
+import com.growup.pms.team.dto.TeamResponse;
+import com.growup.pms.team.repository.TeamRepository;
+import com.growup.pms.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TeamService {
+    private final TeamRepository teamRepository;
+    private final UserRepository userRepository;
+
+    public TeamResponse getTeam(Long teamId) {
+        return TeamResponse.from(teamRepository.findByIdOrThrow(teamId));
+    }
+
+    public Long createTeam(TeamCreateRequest request) {
+        return teamRepository.save(TeamCreateRequest.toEntity(request, userRepository.findByIdOrThrow(request.getCreatorId())))
+                .getId();
+    }
+
+    public void deleteTeam(Long teamId) {
+        teamRepository.deleteById(teamId);
+    }
+}

--- a/src/main/java/com/growup/pms/team/service/TeamService.java
+++ b/src/main/java/com/growup/pms/team/service/TeamService.java
@@ -8,6 +8,7 @@ import com.growup.pms.team.repository.TeamRepository;
 import com.growup.pms.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -29,6 +30,7 @@ public class TeamService {
         teamRepository.deleteById(teamId);
     }
 
+    @Transactional
     public void updateTeam(Long teamId, TeamUpdateRequest request) {
         Team team = teamRepository.findByIdOrThrow(teamId);
         if (request.getName().isPresent()) {
@@ -37,6 +39,5 @@ public class TeamService {
         if (request.getContent().isPresent()) {
             team.updateContent(request.getContent().get());
         }
-        teamRepository.save(team);
     }
 }

--- a/src/test/java/com/growup/pms/auth/controller/LoginControllerV1Test.java
+++ b/src/test/java/com/growup/pms/auth/controller/LoginControllerV1Test.java
@@ -52,9 +52,11 @@ class LoginControllerV1Test extends CommonControllerSliceTest {
             mockMvc.perform(post("/api/v1/user/login")
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(validRequest)))
-                    .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.accessToken").value(TokenDtoFixture.VALID_ACCESS_TOKEN))
-                    .andExpect(cookie().value("refreshToken", TokenDtoFixture.VALID_REFRESH_TOKEN));
+                    .andExpectAll(
+                            status().isOk(),
+                            jsonPath("$.accessToken").value(TokenDtoFixture.VALID_ACCESS_TOKEN),
+                            cookie().value("refreshToken", TokenDtoFixture.VALID_REFRESH_TOKEN)
+                    );
         }
 
         @Test
@@ -69,9 +71,11 @@ class LoginControllerV1Test extends CommonControllerSliceTest {
             mockMvc.perform(post("/api/v1/user/login")
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(badRequest)))
-                    .andExpect(status().isNotFound())
-                    .andExpect(jsonPath("$.accessToken").doesNotExist())
-                    .andExpect(cookie().doesNotExist("refreshToken"));
+                    .andExpectAll(
+                            status().isNotFound(),
+                            jsonPath("$.accessToken").doesNotExist(),
+                            cookie().doesNotExist("refreshToken")
+                    );
         }
     }
 
@@ -90,9 +94,11 @@ class LoginControllerV1Test extends CommonControllerSliceTest {
             mockMvc.perform(post("/api/v1/user/login/refresh")
                             .contentType(MediaType.APPLICATION_JSON)
                             .cookie(new Cookie("refreshToken", validRefreshToken)))
-                    .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.accessToken").value(newTokens.getAccessToken()))
-                    .andExpect(cookie().value("refreshToken", newTokens.getRefreshToken()));
+                    .andExpectAll(
+                            status().isOk(),
+                            jsonPath("$.accessToken").value(newTokens.getAccessToken()),
+                            cookie().value("refreshToken", newTokens.getRefreshToken())
+                    );
         }
 
         @Test
@@ -104,8 +110,10 @@ class LoginControllerV1Test extends CommonControllerSliceTest {
             mockMvc.perform(post("/api/v1/user/login/refresh")
                         .contentType(MediaType.APPLICATION_JSON)
                         .cookie(new Cookie("refreshToken", TokenDtoFixture.INVALID_REFRESH_TOKEN)))
-                    .andExpect(status().isUnauthorized())
-                    .andExpect(jsonPath("$.accessToken").doesNotExist());
+                    .andExpectAll(
+                            status().isUnauthorized(),
+                            jsonPath("$.accessToken").doesNotExist()
+                    );
         }
     }
 }

--- a/src/test/java/com/growup/pms/auth/controller/LoginControllerV1Test.java
+++ b/src/test/java/com/growup/pms/auth/controller/LoginControllerV1Test.java
@@ -69,7 +69,7 @@ class LoginControllerV1Test extends CommonControllerSliceTest {
             mockMvc.perform(post("/api/v1/user/login")
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(badRequest)))
-                    .andExpect(status().isBadRequest())
+                    .andExpect(status().isNotFound())
                     .andExpect(jsonPath("$.accessToken").doesNotExist())
                     .andExpect(cookie().doesNotExist("refreshToken"));
         }

--- a/src/test/java/com/growup/pms/auth/service/JwtLoginServiceTest.java
+++ b/src/test/java/com/growup/pms/auth/service/JwtLoginServiceTest.java
@@ -1,7 +1,7 @@
 package com.growup.pms.auth.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 
@@ -76,8 +76,10 @@ class JwtLoginServiceTest {
             TokenDto actualNewToken = loginService.authenticateUser(validRequest);
 
             // then
-            assertThat(actualNewToken).isNotNull();
-            assertThat(expectedNewToken).isEqualTo(actualNewToken);
+            assertSoftly(softly -> {
+                softly.assertThat(actualNewToken).isNotNull();
+                softly.assertThat(expectedNewToken).isEqualTo(actualNewToken);
+            });
         }
 
         @Test

--- a/src/test/java/com/growup/pms/common/exception/handler/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/growup/pms/common/exception/handler/GlobalExceptionHandlerTest.java
@@ -68,7 +68,7 @@ class GlobalExceptionHandlerTest {
 
         // when & then
         mockMvc.perform(MockMvcRequestBuilders.get(url))
-            .andExpect(status().isBadRequest())
+            .andExpect(status().isNotFound())
             .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("Entity error: ENTITY가 없습니다."))
             .andExpect(MockMvcResultMatchers.jsonPath("$.code").value("ET_001"));
     }

--- a/src/test/java/com/growup/pms/team/controller/TeamControllerV1Test.java
+++ b/src/test/java/com/growup/pms/team/controller/TeamControllerV1Test.java
@@ -1,0 +1,179 @@
+package com.growup.pms.team.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.growup.pms.common.exception.code.ErrorCode;
+import com.growup.pms.common.exception.exceptions.EntityNotFoundException;
+import com.growup.pms.team.dto.TeamCreateRequest;
+import com.growup.pms.team.dto.TeamResponse;
+import com.growup.pms.team.dto.TeamUpdateRequest;
+import com.growup.pms.team.service.TeamService;
+import com.growup.pms.test.CommonControllerSliceTest;
+import com.growup.pms.test.annotation.AutoKoreanDisplayName;
+import com.growup.pms.test.fixture.team.TeamFixture;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.openapitools.jackson.nullable.JsonNullable;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+@AutoKoreanDisplayName
+@SuppressWarnings("NonAsciiCharacters")
+@WithMockUser
+class TeamControllerV1Test extends CommonControllerSliceTest {
+    @Autowired
+    TeamService teamService;
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Nested
+    class 사용자가_팀을_조회_시에 {
+
+        @Test
+        void 성공한다() throws Exception {
+            // given
+            Long teamId = TeamFixture.DEFAULT_TEAM_ID;
+            TeamResponse expectedResult = TeamFixture.createDefaultTeamResponse();
+
+            when(teamService.getTeam(teamId)).thenReturn(expectedResult);
+
+            // when & then
+            mockMvc.perform(get("/api/v1/team/" + teamId))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.name").value(expectedResult.getName()))
+                    .andExpect(jsonPath("$.content").value(expectedResult.getContent()));
+        }
+
+        @Test
+        void 존재하지_않는_팀_조회_시_404_에러를_반환한다() throws Exception {
+            // given
+            Long teamId = TeamFixture.DEFAULT_TEAM_ID;
+
+            when(teamService.getTeam(teamId)).thenThrow(new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND));
+
+            // when & then
+            mockMvc.perform(get("/api/v1/team/" + teamId))
+                    .andExpect(status().isNotFound());
+        }
+    }
+
+    @Nested
+    class 사용자가_팀을_생성_시에 {
+
+        @Test
+        void 성공한다() throws Exception {
+            // given
+            Long expectedTeamId = TeamFixture.DEFAULT_TEAM_ID;
+            TeamCreateRequest request = TeamFixture.createDefaultTeamCreateRequest();
+
+            when(teamService.createTeam(any(TeamCreateRequest.class))).thenReturn(expectedTeamId);
+
+            // when & then
+            mockMvc.perform(post("/api/v1/team")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request))
+                            .with(csrf()))
+                    .andExpect(status().isCreated())
+                    .andExpect(header().string(HttpHeaders.LOCATION, "/api/v1/team/" + expectedTeamId));
+        }
+
+        @Test
+        void 유효하지_않은_입력으로_팀_생성_시_400_에러를_반환한다() throws Exception {
+            // given
+            String invalidTeamName = "!#$&-_이름";
+            TeamCreateRequest request = TeamFixture.createDefaultTeamCreateRequestBuilder()
+                    .name(invalidTeamName)
+                    .build();
+
+            // when & then
+            mockMvc.perform(post("/api/v1/team")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request))
+                            .with(csrf()))
+                    .andExpect(status().isBadRequest());
+        }
+    }
+
+    @Nested
+    class 사용자가_팀을_변경_시에 {
+
+        @Test
+        void 성공한다() throws Exception {
+            // given
+            Long teamId = TeamFixture.DEFAULT_TEAM_ID;
+            TeamCreateRequest request = TeamFixture.createDefaultTeamCreateRequest();
+
+            doNothing().when(teamService).updateTeam(eq(teamId), any(TeamUpdateRequest.class));
+
+            // when & then
+            mockMvc.perform(patch("/api/v1/team/" + teamId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request))
+                    .with(csrf()))
+                .andExpect(status().isNoContent());
+        }
+
+        @Test
+        void 유효하지_않은_입력으로_팀_변경_시_400_에러를_반환한다() throws Exception {
+            // given
+            Long teamId = TeamFixture.DEFAULT_TEAM_ID;
+            String invalidTeamName = "!#$&-_이름";
+            TeamUpdateRequest request = TeamFixture.createDefaultTeamUpdateRequestBuilder()
+                    .name(JsonNullable.of(invalidTeamName))
+                    .build();
+
+            doNothing().when(teamService).updateTeam(eq(teamId), any(TeamUpdateRequest.class));
+
+            // when & then
+            mockMvc.perform(patch("/api/v1/team/" + teamId)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request))
+                            .with(csrf()))
+                    .andExpect(status().isBadRequest());
+        }
+    }
+
+    @Nested
+    class 사용자가_팀을_제거_시에 {
+
+        @Test
+        void 성공한다() throws Exception {
+            // given
+            Long teamId = TeamFixture.DEFAULT_TEAM_ID;
+
+            doNothing().when(teamService).deleteTeam(teamId);
+
+            // when & then
+            mockMvc.perform(delete("/api/v1/team/" + teamId).with(csrf()))
+                    .andExpect(status().isNoContent());
+        }
+
+        @Test
+        void 존재하지_않는_팀_제거_시_404_에러를_반환한다() throws Exception {
+            // given
+            Long teamId = TeamFixture.DEFAULT_TEAM_ID;
+
+            doThrow(new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND)).when(teamService).deleteTeam(teamId);
+
+            // when & then
+            mockMvc.perform(delete("/api/v1/team/" + teamId).with(csrf()))
+                    .andExpect(status().isNotFound());
+        }
+    }
+}

--- a/src/test/java/com/growup/pms/team/controller/TeamControllerV1Test.java
+++ b/src/test/java/com/growup/pms/team/controller/TeamControllerV1Test.java
@@ -22,6 +22,7 @@ import com.growup.pms.team.dto.TeamUpdateRequest;
 import com.growup.pms.team.service.TeamService;
 import com.growup.pms.test.CommonControllerSliceTest;
 import com.growup.pms.test.annotation.AutoKoreanDisplayName;
+import com.growup.pms.test.annotation.WithMockSecurityUser;
 import com.growup.pms.test.fixture.team.TeamFixture;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -77,12 +78,14 @@ class TeamControllerV1Test extends CommonControllerSliceTest {
     class 사용자가_팀을_생성_시에 {
 
         @Test
+        @WithMockSecurityUser(id = 1L)
         void 성공한다() throws Exception {
             // given
+            Long creatorId = 1L;
             Long expectedTeamId = TeamFixture.DEFAULT_TEAM_ID;
             TeamCreateRequest request = TeamFixture.createDefaultTeamCreateRequest();
 
-            when(teamService.createTeam(any(TeamCreateRequest.class))).thenReturn(expectedTeamId);
+            when(teamService.createTeam(eq(creatorId), any(TeamCreateRequest.class))).thenReturn(expectedTeamId);
 
             // when & then
             mockMvc.perform(post("/api/v1/team")

--- a/src/test/java/com/growup/pms/team/controller/TeamControllerV1Test.java
+++ b/src/test/java/com/growup/pms/team/controller/TeamControllerV1Test.java
@@ -56,9 +56,11 @@ class TeamControllerV1Test extends CommonControllerSliceTest {
 
             // when & then
             mockMvc.perform(get("/api/v1/team/" + teamId))
-                    .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.name").value(expectedResult.getName()))
-                    .andExpect(jsonPath("$.content").value(expectedResult.getContent()));
+                    .andExpectAll(
+                            status().isOk(),
+                            jsonPath("$.name").value(expectedResult.getName()),
+                            jsonPath("$.content").value(expectedResult.getContent())
+                    );
         }
 
         @Test
@@ -92,8 +94,10 @@ class TeamControllerV1Test extends CommonControllerSliceTest {
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request))
                             .with(csrf()))
-                    .andExpect(status().isCreated())
-                    .andExpect(header().string(HttpHeaders.LOCATION, "/api/v1/team/" + expectedTeamId));
+                    .andExpectAll(
+                            status().isCreated(),
+                            header().string(HttpHeaders.LOCATION, "/api/v1/team/" + expectedTeamId)
+                    );
         }
 
         @Test

--- a/src/test/java/com/growup/pms/team/service/TeamServiceTest.java
+++ b/src/test/java/com/growup/pms/team/service/TeamServiceTest.java
@@ -1,0 +1,158 @@
+package com.growup.pms.team.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.growup.pms.common.exception.code.ErrorCode;
+import com.growup.pms.common.exception.exceptions.EntityNotFoundException;
+import com.growup.pms.team.domain.Team;
+import com.growup.pms.team.dto.TeamCreateRequest;
+import com.growup.pms.team.dto.TeamResponse;
+import com.growup.pms.team.dto.TeamUpdateRequest;
+import com.growup.pms.team.repository.TeamRepository;
+import com.growup.pms.test.annotation.AutoKoreanDisplayName;
+import com.growup.pms.test.fixture.team.TeamFixture;
+import com.growup.pms.test.fixture.user.UserFixture;
+import com.growup.pms.user.repository.UserRepository;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.openapitools.jackson.nullable.JsonNullable;
+import org.springframework.security.test.context.support.WithMockUser;
+
+@AutoKoreanDisplayName
+@SuppressWarnings("NonAsciiCharacters")
+@WithMockUser
+@ExtendWith(MockitoExtension.class)
+class TeamServiceTest {
+    @Mock
+    TeamRepository teamRepository;
+
+    @Mock
+    UserRepository userRepository;
+
+    @InjectMocks
+    TeamService teamService;
+
+    @Nested
+    class 팀_생성_시에 {
+
+        @Test
+        void 성공한다() {
+            // given
+            Long creatorId = 1L;
+            Long expectedTeamId = 1L;
+            Team createdTeam = mock(Team.class);
+            TeamCreateRequest request = TeamFixture.createDefaultTeamCreateRequest();
+
+            when(userRepository.findByIdOrThrow(creatorId)).thenReturn(UserFixture.createUserWithId(creatorId));
+            when(teamRepository.save(any(Team.class))).thenReturn(createdTeam);
+            when(createdTeam.getId()).thenReturn(expectedTeamId);
+
+            // when
+            Long actualTeamId = teamService.createTeam(creatorId, request);
+
+            // then
+            assertThat(actualTeamId).isEqualTo(expectedTeamId);
+        }
+
+        @Test
+        void 사용자가_존재하지_않으면_예외가_발생한다() {
+            // given
+            Long creatorId = 1L;
+            TeamCreateRequest request = TeamFixture.createDefaultTeamCreateRequest();
+
+            doThrow(new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND)).when(userRepository).findByIdOrThrow(creatorId);
+
+            // when & then
+            assertThrows(EntityNotFoundException.class, () -> teamService.createTeam(creatorId, request));
+
+
+        }
+    }
+
+    @Nested
+    class 팀_조회_시에 {
+
+        @Test
+        void 성공한다() {
+            // given
+            Long teamId = 1L;
+            Team team = TeamFixture.createTeamWithId(teamId);
+            TeamResponse expectedResponse = TeamResponse.from(team);
+
+            when(teamRepository.findByIdOrThrow(teamId)).thenReturn(team);
+
+            // when
+            TeamResponse actualResponse = teamService.getTeam(teamId);
+
+            // then
+            assertThat(actualResponse.getName()).isEqualTo(expectedResponse.getName());
+            assertThat(actualResponse.getContent()).isEqualTo(expectedResponse.getContent());
+        }
+
+        @Test
+        void 팀이_존재하지_않으면_예외가_발생한다() {
+            // given
+            Long teamId = 1L;
+
+            doThrow(new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND)).when(teamRepository).findByIdOrThrow(teamId);
+
+            // when & then
+            assertThrows(EntityNotFoundException.class, () -> teamService.getTeam(teamId));
+        }
+    }
+
+    @Nested
+    class 팀_변경_시에 {
+
+        @Test
+        void 성공한다() {
+            // given
+            Long teamId = 1L;
+            Team team = TeamFixture.createTeamWithId(teamId);
+            String newTeamName = "구구팔";
+            String newTeamContent = "안녕하세요, 구구팔입니다!";
+            TeamUpdateRequest request = TeamFixture.createDefaultTeamUpdateRequestBuilder()
+                    .name(JsonNullable.of(newTeamName))
+                    .content(JsonNullable.of(newTeamContent))
+                    .build();
+
+            when(teamRepository.findByIdOrThrow(teamId)).thenReturn(team);
+
+            // when
+            teamService.updateTeam(teamId, request);
+
+            // then
+            assertThat(team.getName()).isEqualTo(newTeamName);
+            assertThat(team.getContent()).isEqualTo(newTeamContent);
+        }
+    }
+
+    @Nested
+    class 팀_삭제_시에 {
+
+        @Test
+        void 성공한다() {
+            // given
+            Long teamId = 1L;
+
+            doNothing().when(teamRepository).deleteById(teamId);
+
+            // when
+            teamService.deleteTeam(teamId);
+
+            // then
+            verify(teamRepository).deleteById(teamId);
+        }
+    }
+}

--- a/src/test/java/com/growup/pms/team/service/TeamServiceTest.java
+++ b/src/test/java/com/growup/pms/team/service/TeamServiceTest.java
@@ -2,7 +2,7 @@ package com.growup.pms.team.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
@@ -96,8 +96,10 @@ class TeamServiceTest {
             TeamResponse actualResponse = teamService.getTeam(teamId);
 
             // then
-            assertThat(actualResponse.getName()).isEqualTo(expectedResponse.getName());
-            assertThat(actualResponse.getContent()).isEqualTo(expectedResponse.getContent());
+            assertSoftly(softly -> {
+                softly.assertThat(actualResponse.getName()).isEqualTo(expectedResponse.getName());
+                softly.assertThat(actualResponse.getContent()).isEqualTo(expectedResponse.getContent());
+            });
         }
 
         @Test
@@ -108,7 +110,8 @@ class TeamServiceTest {
             doThrow(new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND)).when(teamRepository).findByIdOrThrow(teamId);
 
             // when & then
-            assertThrows(EntityNotFoundException.class, () -> teamService.getTeam(teamId));
+            assertThatThrownBy(() -> teamService.getTeam(teamId))
+                    .isInstanceOf(EntityNotFoundException.class);
         }
     }
 
@@ -133,8 +136,10 @@ class TeamServiceTest {
             teamService.updateTeam(teamId, request);
 
             // then
-            assertThat(team.getName()).isEqualTo(newTeamName);
-            assertThat(team.getContent()).isEqualTo(newTeamContent);
+            assertSoftly(softly -> {
+                softly.assertThat(team.getName()).isEqualTo(newTeamName);
+                softly.assertThat(team.getContent()).isEqualTo(newTeamContent);
+            });
         }
     }
 

--- a/src/test/java/com/growup/pms/team/service/TeamServiceTest.java
+++ b/src/test/java/com/growup/pms/team/service/TeamServiceTest.java
@@ -1,6 +1,7 @@
 package com.growup.pms.team.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
@@ -74,9 +75,8 @@ class TeamServiceTest {
             doThrow(new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND)).when(userRepository).findByIdOrThrow(creatorId);
 
             // when & then
-            assertThrows(EntityNotFoundException.class, () -> teamService.createTeam(creatorId, request));
-
-
+            assertThatThrownBy(() -> teamService.createTeam(creatorId, request))
+                    .isInstanceOf(EntityNotFoundException.class);
         }
     }
 

--- a/src/test/java/com/growup/pms/test/CommonControllerSliceTest.java
+++ b/src/test/java/com/growup/pms/test/CommonControllerSliceTest.java
@@ -1,6 +1,7 @@
 package com.growup.pms.test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.growup.pms.common.config.ObjectMapperConfig;
 import com.growup.pms.common.security.jwt.JwtTokenProvider;
 import com.growup.pms.test.annotation.AutoServiceMockBeans;
 import org.junit.jupiter.api.AfterEach;
@@ -12,12 +13,14 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.ComponentScan.Filter;
 import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Import;
 import org.springframework.stereotype.Service;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.context.WebApplicationContext;
 
+@Import(ObjectMapperConfig.class)
 @AutoServiceMockBeans(basePackage = "com.growup.pms")
 @WebMvcTest(includeFilters = @Filter(type = FilterType.ANNOTATION, classes = RestController.class))
 public abstract class CommonControllerSliceTest {

--- a/src/test/java/com/growup/pms/test/annotation/WithMockSecurityUser.java
+++ b/src/test/java/com/growup/pms/test/annotation/WithMockSecurityUser.java
@@ -1,0 +1,35 @@
+package com.growup.pms.test.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.core.annotation.AliasFor;
+import org.springframework.security.test.context.support.TestExecutionEvent;
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Documented
+@WithSecurityContext(
+        factory = WithMockSecurityUserSecurityContextFactory.class
+)
+public @interface WithMockSecurityUser {
+    @AliasFor("email")
+    String value() default "user@example.com";
+
+    @AliasFor("value")
+    String email() default "user@example.com";
+
+    long id() default 1L;
+
+    String password() default "password";
+
+    @AliasFor(
+            annotation = WithSecurityContext.class
+    )
+    TestExecutionEvent setupBefore() default TestExecutionEvent.TEST_METHOD;
+}

--- a/src/test/java/com/growup/pms/test/annotation/WithMockSecurityUserSecurityContextFactory.java
+++ b/src/test/java/com/growup/pms/test/annotation/WithMockSecurityUserSecurityContextFactory.java
@@ -1,0 +1,25 @@
+package com.growup.pms.test.annotation;
+
+import com.growup.pms.auth.domain.SecurityUser;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+
+public class WithMockSecurityUserSecurityContextFactory implements WithSecurityContextFactory<WithMockSecurityUser> {
+
+    @Override
+    public SecurityContext createSecurityContext(WithMockSecurityUser securityUser) {
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+
+        SecurityUser principal = SecurityUser.builder()
+                .id(securityUser.id())
+                .email(securityUser.email())
+                .password(securityUser.password())
+                .build();
+
+        var auth = new UsernamePasswordAuthenticationToken(principal, principal.getPassword(), principal.getAuthorities());
+        context.setAuthentication(auth);
+        return context;
+    }
+}

--- a/src/test/java/com/growup/pms/test/fixture/team/TeamFixture.java
+++ b/src/test/java/com/growup/pms/test/fixture/team/TeamFixture.java
@@ -35,8 +35,17 @@ public class TeamFixture {
     public static TeamCreateRequest.TeamCreateRequestBuilder createDefaultTeamCreateRequestBuilder() {
         return TeamCreateRequest.builder()
                 .name(DEFAULT_TEAM_NAME)
-                .content(DEFAULT_TEAM_CONTENT)
-                .creatorId(DEFAULT_TEAM_ID);
+                .content(DEFAULT_TEAM_CONTENT);
+    }
+
+    public static TeamUpdateRequest createDefaultTeamUpdateRequest() {
+        return createDefaultTeamUpdateRequestBuilder().build();
+    }
+
+    public static TeamUpdateRequest.TeamUpdateRequestBuilder createDefaultTeamUpdateRequestBuilder() {
+        return TeamUpdateRequest.builder()
+                .name(JsonNullable.of(DEFAULT_TEAM_NAME))
+                .content(JsonNullable.of(DEFAULT_TEAM_CONTENT));
     }
 
     public static TeamResponse createDefaultTeamResponse() {
@@ -47,11 +56,5 @@ public class TeamFixture {
         return TeamResponse.builder()
                 .name(DEFAULT_TEAM_NAME)
                 .content(DEFAULT_TEAM_CONTENT);
-    }
-
-    public static TeamUpdateRequest.TeamUpdateRequestBuilder createDefaultTeamUpdateRequestBuilder() {
-        return TeamUpdateRequest.builder()
-                .name(JsonNullable.of(DEFAULT_TEAM_NAME))
-                .content(JsonNullable.of(DEFAULT_TEAM_CONTENT));
     }
 }

--- a/src/test/java/com/growup/pms/test/fixture/team/TeamFixture.java
+++ b/src/test/java/com/growup/pms/test/fixture/team/TeamFixture.java
@@ -1,0 +1,57 @@
+package com.growup.pms.test.fixture.team;
+
+import com.growup.pms.team.domain.Team;
+import com.growup.pms.team.dto.TeamCreateRequest;
+import com.growup.pms.team.dto.TeamResponse;
+import com.growup.pms.team.dto.TeamUpdateRequest;
+import org.openapitools.jackson.nullable.JsonNullable;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class TeamFixture {
+    public static final Long DEFAULT_TEAM_ID = 1L;
+    public static final String DEFAULT_TEAM_NAME = "구구구";
+    public static final String DEFAULT_TEAM_CONTENT = "안녕하세요, 구구구입니다!";
+
+    public static Team createDefaultTeam() {
+        return createTeamWithId(DEFAULT_TEAM_ID);
+    }
+
+    public static Team createTeamWithId(Long id) {
+        Team team = createDefaultTeamBuilder().build();
+        ReflectionTestUtils.setField(team, "id", id);
+        return team;
+    }
+
+    public static Team.TeamBuilder createDefaultTeamBuilder() {
+        return Team.builder()
+                .name(DEFAULT_TEAM_NAME)
+                .content(DEFAULT_TEAM_CONTENT);
+    }
+
+    public static TeamCreateRequest createDefaultTeamCreateRequest() {
+        return createDefaultTeamCreateRequestBuilder().build();
+    }
+
+    public static TeamCreateRequest.TeamCreateRequestBuilder createDefaultTeamCreateRequestBuilder() {
+        return TeamCreateRequest.builder()
+                .name(DEFAULT_TEAM_NAME)
+                .content(DEFAULT_TEAM_CONTENT)
+                .creatorId(DEFAULT_TEAM_ID);
+    }
+
+    public static TeamResponse createDefaultTeamResponse() {
+        return createDefaultTeamResponseBuilder().build();
+    }
+
+    public static TeamResponse.TeamResponseBuilder createDefaultTeamResponseBuilder() {
+        return TeamResponse.builder()
+                .name(DEFAULT_TEAM_NAME)
+                .content(DEFAULT_TEAM_CONTENT);
+    }
+
+    public static TeamUpdateRequest.TeamUpdateRequestBuilder createDefaultTeamUpdateRequestBuilder() {
+        return TeamUpdateRequest.builder()
+                .name(JsonNullable.of(DEFAULT_TEAM_NAME))
+                .content(JsonNullable.of(DEFAULT_TEAM_CONTENT));
+    }
+}

--- a/src/test/java/com/growup/pms/user/controller/UserControllerV1Test.java
+++ b/src/test/java/com/growup/pms/user/controller/UserControllerV1Test.java
@@ -13,6 +13,7 @@ import com.growup.pms.user.dto.UserCreateRequest;
 import com.growup.pms.user.service.UserService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 
 @AutoKoreanDisplayName
@@ -33,7 +34,9 @@ class UserControllerV1Test extends CommonControllerSliceTest {
         mockMvc.perform(post("/api/v1/users")
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isCreated())
-                .andExpect(header().string("Location", "/api/v1/users/" + userId));
+                .andExpectAll(
+                        status().isCreated(),
+                        header().string(HttpHeaders.LOCATION, "/api/v1/users/" + userId)
+                );
     }
 }


### PR DESCRIPTION
## PR Type

- [x] **\[Fix\]** 🐞 버그를 수정했어요.
- [x] **\[Feat\]** 🎨 새로운 기능을 추가했어요.
- [x] **\[Style\]** 🧬 코드 스타일 업데이트를 했어요(포맷팅, 변수명 변경 etc)
- [x] **\[Refactor\]** 🛠 리팩토링을 했어요 (기능적인 변화 없이, api 변경 없이)
- [x] **\[Test\]** 🧪 테스트 코드를 추가/삭제/변경 했어요.
- [x] **\[Chore\]** 🛒 빌드 프로세스 변경, 의존성 패키지 업데이트 했어요.

## Related Issues

- close #39 

## What does this PR do?

- [x] 팀 CRUD API를 구현함
- [x] 스프링 시큐리티 테스트를 용이하게 하기 위해 커스텀 팩토리 클래스과 애노테이션을 정의함
- [x] 좀 더 유연한 json patch를 위해서 의존성을 추가함

## Other information
### 좀 더 유연한 PATCH API 설계하기
#### 문제점 발견
PATCH는 보통 리소스를 부분적으로 수정할 때 사용한다. JSON에서 어떤 필드가 존재하면 해당 필드를 주어진 값으로 업데이트 하라는 의미가 되고, 만약에 어떤 필드가 없다면 그 필드는 변경 대상이 아니라고 볼 수 있다. 

하지만 아래와 같이 `PATCH`에 사용되는 DTO가 있다고 해보자. 이 경우에는 필드를 생략하건 null로 값을 주건 두 가지 경우 모두 해당 필드에 null 값이 들어가게 된다. 이 경우에는 해당 필드를 null로 업데이트 하라는 것인지, 아니면 변경 대상이 아니라는 것인지 구분을 할 수 없는 문제가 생긴다.

```java
@Getter
@NoArgsConstructor(access = AccessLevel.PRIVATE)
public class TeamUpdateRequest {
	@Pattern(regexp = "^[가-힣a-zA-Z0-9]{1,10}$", message = "팀 이름은 한글, 영문, 숫자로 구성된 1~10자리여야 합니다.")
    private String name;

    private String content;

    @Builder
    public TeamUpdateRequest(String name, String content) {
        this.name = name;
        this.content = content;
    }
}
```

만약에 여기서 `content`만 변경하고 싶은 경우에는 name에서 검증 에러가 발생하면 안될 것이다. JSON에 어떤 필드가 없다면 해당 필드에 대한 검증을 생략하도록 만들어야 한다.

#### 해결 방안
여러 방안이 있지만 2번에 대해서는 추가적인 의논이 필요할 것 같고, 3번은 프론트 측에서 정한 명세와 달라질 수 있으며, 1번은 다소 코드가 장황해질 수 있기 때문에 가장 유연한 방법인 4번 방법에 대해서 추가적으로 조사했다.

1. 프로그래밍 방식으로 빈의 유효성을 검증하기(validator를 주입받거나 custom validator를 정의하는 방법 등)
2. 업데이트 시 필요한 필드만 모아서 `~UpdateRequest` 만들기
3. `PATCH` 대신 `PUT`을 사용하기
4. [JsonNullable](https://github.com/OpenAPITools/jackson-databind-nullable) 의존성 사용하기

##### jackson-databind-nullable
[이 모듈](https://mvnrepository.com/artifact/org.openapitools/jackson-databind-nullable)에서는 `JsonNullable` 래퍼 클래스와 이를 직렬화/역직렬화하기 위한 Jackson 모듈을 제공한다. `JsonNullable` 래퍼 클래스는 명시적인 “null”과 필드가 존재하지 않음을 구분하는 게 중요할 때 사용할 수 있다.

```java
public static class Pet {
    
    @Size(max = 10)   
    public JsonNullable<String> name = JsonNullable.undefined();
    
    public Pet name(JsonNullable<String> name) {
        this.name = name;
        return this;
    }
}
```

## References
- [OpenAPITools/jackson-databind-nullable](https://github.com/OpenAPITools/jackson-databind-nullable)