### PR TITLE
Feat: #64 응답 바디 대신에 헤더를 통해서 액세스 토큰을 전달하도록 함

### DIFF
--- a/src/main/java/com/growup/pms/auth/controller/LoginControllerV1.java
+++ b/src/main/java/com/growup/pms/auth/controller/LoginControllerV1.java
@@ -10,6 +10,7 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -30,14 +31,17 @@ public class LoginControllerV1 {
         TokenDto tokenDto = loginService.authenticateUser(request);
         setRefreshTokenCookie(response, tokenDto.getRefreshToken());
         return ResponseEntity.ok()
-                .body(AccessTokenResponse.builder().accessToken(tokenDto.getAccessToken()).build());
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + tokenDto.getAccessToken())
+                .build();
     }
 
     @PostMapping("/refresh")
     public ResponseEntity<AccessTokenResponse> refresh(@CookieValue("refreshToken") String refreshToken, HttpServletResponse response) {
         TokenDto tokenDto = tokenService.refreshJwtTokens(refreshToken);
         setRefreshTokenCookie(response, tokenDto.getRefreshToken());
-        return ResponseEntity.ok().body(AccessTokenResponse.builder().accessToken(tokenDto.getAccessToken()).build());
+        return ResponseEntity.ok()
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + tokenDto.getAccessToken())
+                .build();
     }
 
     private void setRefreshTokenCookie(HttpServletResponse response, String refreshToken) {

--- a/src/test/java/com/growup/pms/auth/controller/LoginControllerV1Test.java
+++ b/src/test/java/com/growup/pms/auth/controller/LoginControllerV1Test.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -23,6 +24,7 @@ import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 
 @AutoKoreanDisplayName
@@ -54,7 +56,7 @@ class LoginControllerV1Test extends CommonControllerSliceTest {
                             .content(objectMapper.writeValueAsString(validRequest)))
                     .andExpectAll(
                             status().isOk(),
-                            jsonPath("$.accessToken").value(TokenDtoFixture.VALID_ACCESS_TOKEN),
+                            header().string(HttpHeaders.AUTHORIZATION, "Bearer " + TokenDtoFixture.VALID_ACCESS_TOKEN),
                             cookie().value("refreshToken", TokenDtoFixture.VALID_REFRESH_TOKEN)
                     );
         }
@@ -96,7 +98,7 @@ class LoginControllerV1Test extends CommonControllerSliceTest {
                             .cookie(new Cookie("refreshToken", validRefreshToken)))
                     .andExpectAll(
                             status().isOk(),
-                            jsonPath("$.accessToken").value(newTokens.getAccessToken()),
+                            header().string(HttpHeaders.AUTHORIZATION, "Bearer " + newTokens.getAccessToken()),
                             cookie().value("refreshToken", newTokens.getRefreshToken())
                     );
         }


### PR DESCRIPTION
## PR Type

- [x] **\[Feat\]** 🎨 새로운 기능을 추가했어요.
- [x] **\[Test\]** 🧪 테스트 코드를 추가/삭제/변경 했어요.

## Related Issues

- close #64 

## What does this PR do?

- [x] 응답 바디 대신에 헤더를 통해 액세스 토큰을 전달함
- [x] 슬라이스 테스트에도 헤더를 통해 액세스 토큰을 검증하도록 함

## Other information

- API 명세서에 맞춰서 바디가 아닌 헤더를 통해 전달하도록 수정했습니다 :smiley: 