### PR TITLE
Config: #68 Spring REST Docs를 위한 초기 환경을 구성함

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ out/
 
 ### Qodana ###
 .qodana/
+
+### Docs ###
+/src/main/resources/static/docs/

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'jacoco'
     id 'org.springframework.boot' version '3.3.0'
     id 'io.spring.dependency-management' version '1.1.5'
+    id 'org.asciidoctor.jvm.convert' version '3.3.2'
 }
 
 group = 'com.growup'
@@ -18,6 +19,7 @@ configurations {
     compileOnly {
         extendsFrom annotationProcessor
     }
+    asciidoctorExt
 }
 
 repositories {
@@ -45,11 +47,38 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
     implementation 'org.openapitools:jackson-databind-nullable:0.2.6'
+    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+    asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
+}
+
+ext {
+    set('snippetsDir', file("build/generated-snippets"))
 }
 
 tasks.named('test') {
+    outputs.dir snippetsDir
     useJUnitPlatform()
     finalizedBy 'jacocoTestReport'
+}
+
+tasks.named('asciidoctor') {
+    inputs.dir snippetsDir
+    configurations 'asciidoctorExt'
+    dependsOn test
+}
+
+tasks.register('copyDocument', Copy) {
+    dependsOn asciidoctor
+    from file('build/docs/asciidoc')
+    into file('src/main/resources/static/docs')
+}
+
+asciidoctor.doFirst {
+    delete file('src/main/resources/static/docs')
+}
+
+build {
+    dependsOn copyDocument
 }
 
 jacoco {

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1,0 +1,15 @@
+= REST API 문서
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+:sectlinks:
+:operation-http-request-title: HTTP 요청
+:operation-http-response-title: HTTP 응답
+:operation-request-headers-title: 요청 헤더
+:operation-request-body-title: 요청 본문
+:operation-response-headers-title: 응답 헤더
+
+= 멤버 API
+== 멤버 생성

--- a/src/test/java/com/growup/pms/auth/controller/LoginControllerV1Test.java
+++ b/src/test/java/com/growup/pms/auth/controller/LoginControllerV1Test.java
@@ -15,7 +15,7 @@ import com.growup.pms.auth.service.JwtTokenService;
 import com.growup.pms.common.exception.code.ErrorCode;
 import com.growup.pms.common.exception.exceptions.AuthenticationException;
 import com.growup.pms.common.exception.exceptions.EntityNotFoundException;
-import com.growup.pms.test.CommonControllerSliceTest;
+import com.growup.pms.test.DefaultControllerSliceTest;
 import com.growup.pms.test.annotation.AutoKoreanDisplayName;
 import com.growup.pms.test.fixture.auth.LoginRequestFixture;
 import com.growup.pms.test.fixture.auth.TokenDtoFixture;
@@ -27,7 +27,7 @@ import org.springframework.http.MediaType;
 
 @AutoKoreanDisplayName
 @SuppressWarnings("NonAsciiCharacters")
-class LoginControllerV1Test extends CommonControllerSliceTest {
+class LoginControllerV1Test extends DefaultControllerSliceTest {
     @Autowired
     private JwtLoginService loginService;
 

--- a/src/test/java/com/growup/pms/team/controller/TeamControllerV1Test.java
+++ b/src/test/java/com/growup/pms/team/controller/TeamControllerV1Test.java
@@ -20,7 +20,7 @@ import com.growup.pms.team.dto.TeamCreateRequest;
 import com.growup.pms.team.dto.TeamResponse;
 import com.growup.pms.team.dto.TeamUpdateRequest;
 import com.growup.pms.team.service.TeamService;
-import com.growup.pms.test.CommonControllerSliceTest;
+import com.growup.pms.test.DefaultControllerSliceTest;
 import com.growup.pms.test.annotation.AutoKoreanDisplayName;
 import com.growup.pms.test.annotation.WithMockSecurityUser;
 import com.growup.pms.test.fixture.team.TeamFixture;
@@ -36,7 +36,7 @@ import org.springframework.test.web.servlet.MockMvc;
 @AutoKoreanDisplayName
 @SuppressWarnings("NonAsciiCharacters")
 @WithMockUser
-class TeamControllerV1Test extends CommonControllerSliceTest {
+class TeamControllerV1Test extends DefaultControllerSliceTest {
     @Autowired
     TeamService teamService;
 

--- a/src/test/java/com/growup/pms/test/AbstractControllerSliceTest.java
+++ b/src/test/java/com/growup/pms/test/AbstractControllerSliceTest.java
@@ -5,7 +5,6 @@ import com.growup.pms.common.config.ObjectMapperConfig;
 import com.growup.pms.common.security.jwt.JwtTokenProvider;
 import com.growup.pms.test.annotation.AutoServiceMockBeans;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
@@ -16,6 +15,8 @@ import org.springframework.context.annotation.FilterType;
 import org.springframework.context.annotation.Import;
 import org.springframework.stereotype.Service;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+import org.springframework.test.web.servlet.setup.DefaultMockMvcBuilder;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.context.WebApplicationContext;
@@ -23,7 +24,7 @@ import org.springframework.web.context.WebApplicationContext;
 @Import(ObjectMapperConfig.class)
 @AutoServiceMockBeans(basePackage = "com.growup.pms")
 @WebMvcTest(includeFilters = @Filter(type = FilterType.ANNOTATION, classes = RestController.class))
-public abstract class CommonControllerSliceTest {
+public abstract class AbstractControllerSliceTest {
     @Autowired
     protected MockMvc mockMvc;
 
@@ -36,14 +37,13 @@ public abstract class CommonControllerSliceTest {
     @MockBean
     protected JwtTokenProvider jwtTokenProvider;
 
-    @BeforeEach
-    void setUpEach(WebApplicationContext context) {
-        this.mockMvc = MockMvcBuilders.webAppContextSetup(context)
-                .build();
+    protected DefaultMockMvcBuilder configureMockMvc(WebApplicationContext context) {
+        return MockMvcBuilders.webAppContextSetup(context)
+                .alwaysDo(MockMvcResultHandlers.print());
     }
 
     @AfterEach
-    void resetMocks() {
+    protected void resetMocks() {
         String[] mockBeanNames = beanFactory.getBeanNamesForAnnotation(Service.class);
         for (String beanName : mockBeanNames) {
             Object bean = beanFactory.getBean(beanName);

--- a/src/test/java/com/growup/pms/test/DefaultControllerSliceTest.java
+++ b/src/test/java/com/growup/pms/test/DefaultControllerSliceTest.java
@@ -1,0 +1,14 @@
+package com.growup.pms.test;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.springframework.web.context.WebApplicationContext;
+
+@Disabled("컨트롤러 슬라이스 테스트 지원이 필요한 테스트 클래스를 만들 때 상속하세요. 직접 실행하지 마세요.")
+public class DefaultControllerSliceTest extends AbstractControllerSliceTest {
+
+    @BeforeEach
+    void setUp(WebApplicationContext context) {
+        this.mockMvc = configureMockMvc(context).build();
+    }
+}

--- a/src/test/java/com/growup/pms/test/DefaultRestDocsControllerSliceTest.java
+++ b/src/test/java/com/growup/pms/test/DefaultRestDocsControllerSliceTest.java
@@ -1,0 +1,29 @@
+package com.growup.pms.test;
+
+import com.growup.pms.test.config.RestDocsConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.web.context.WebApplicationContext;
+
+@Import(RestDocsConfig.class)
+@ExtendWith(RestDocumentationExtension.class)
+@Disabled("컨트롤러 슬라이스 테스트와 REST Docs 지원이 필요한 테스트 클래스를 만들 때 상속하세요. 직접 실행하지 마세요.")
+public class DefaultRestDocsControllerSliceTest extends AbstractControllerSliceTest {
+    @Autowired
+    protected RestDocumentationResultHandler docs;
+
+    @BeforeEach
+    protected void setUpEach(WebApplicationContext context, RestDocumentationContextProvider provider) {
+        this.mockMvc = configureMockMvc(context)
+                .apply(MockMvcRestDocumentation.documentationConfiguration(provider))
+                .alwaysDo(docs)
+                .build();
+    }
+}

--- a/src/test/java/com/growup/pms/test/config/RestDocsConfig.java
+++ b/src/test/java/com/growup/pms/test/config/RestDocsConfig.java
@@ -1,0 +1,20 @@
+package com.growup.pms.test.config;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.restdocs.operation.preprocess.Preprocessors;
+
+@TestConfiguration
+public class RestDocsConfig {
+
+    @Bean
+    public RestDocumentationResultHandler restDocumentationResultHandler() {
+        return MockMvcRestDocumentation.document(
+                "{class-name}/{method-name}",
+                Preprocessors.preprocessRequest(Preprocessors.prettyPrint()),
+                Preprocessors.preprocessResponse(Preprocessors.prettyPrint())
+        );
+    }
+}

--- a/src/test/java/com/growup/pms/user/controller/UserControllerV1Test.java
+++ b/src/test/java/com/growup/pms/user/controller/UserControllerV1Test.java
@@ -6,7 +6,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.growup.pms.test.CommonControllerSliceTest;
+import com.growup.pms.test.DefaultControllerSliceTest;
 import com.growup.pms.test.annotation.AutoKoreanDisplayName;
 import com.growup.pms.test.fixture.user.UserCreateRequestFixture;
 import com.growup.pms.user.dto.UserCreateRequest;
@@ -18,7 +18,7 @@ import org.springframework.http.MediaType;
 
 @AutoKoreanDisplayName
 @SuppressWarnings("NonAsciiCharacters")
-class UserControllerV1Test extends CommonControllerSliceTest {
+class UserControllerV1Test extends DefaultControllerSliceTest {
     @Autowired
     UserService userService;
 


### PR DESCRIPTION
## PR Type

- [x] **\[Refactor\]** 🛠 리팩토링을 했어요 (기능적인 변화 없이, api 변경 없이)
- [x] **\[Config\]** ⚙ 환경설정을 변경했어요.
- [x] **\[Docs\]** 📝 문서 내용을 변경했어요.
- [x] **\[Chore\]** 🛒 빌드 프로세스 변경, 의존성 패키지 업데이트 했어요.

## Related Issues

- close #68

## What does this PR do?

- [x] REST Docs에 대한 의존성을 추가함
- [x] 테스트 용도에 따라서 각각의 클래스를 상속받도록 함

## Other information
### build.gradle에 대한 추가 설명
```java
plugins {
	// Asciidoctor 플러그인을 적용한다. 이 플러그인은 adoc 파일 변환, build 디렉토리에 복사하기 위한 역할을 한다.
	// Gradle 7.0 이상부터는 jvm을 사용한다.
	id 'org.asciidoctor.convert' version '1.5.8'
	// id 'org.asciidoctor.jvm.convert' version '3.3.2'
}

configurations {
	asciidoctorExt 
}

dependencies {
	// build/generated-snippets에 생긴 .adoc 조각들을 프로젝트 내의 .adoc 파일에서 읽어들일 수 있도록 연동해준다.
	// 이 덕분에 .adoc 파일에서 operation 같은 매크로를 사용하여 스니펫 조각들을 연동할 수 있다.
	// 그리고 최종적으로 .adoc 파일을 HTML로 만들어 export 해준다.
	asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
	// MockMvc와 함께 사용한다.
	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
}

ext { // 전역 변수를 설정한다.
	// gradle은 build/generated-snippets에 스니펫이 생성되므로, 이 디렉토리 경로를 해당 변수에 담는다.
	snippetsDir = file('build/generated-snippets')
}

tasks.named('asciidoctor') {
    inputs.dir snippetsDir
    configurations 'asciidoctorExt'
    dependsOn test
}

// build/docs/asciidoc 파일에 생성된 HTML 파일을 src/main/resources/static/docs로 복사하는 작업이다.
tasks.register('copyDocument', Copy) {
    dependsOn asciidoctor
    from file('build/docs/asciidoc')
    into file('src/main/resources/static/docs')
}

// 작업 asciidoctor가 실행되기 전에 이전 HTML 파일이 올라가는 것을 막기 위해서 이전 파일들은 모두 제거한다.
asciidoctor.doFirst {
    delete file('src/main/resources/static/docs')
}

build {
    dependsOn copyDocument
}
```

## Reference
- [Gradle Multi Module에서 Spring Rest Docs 사용하기](https://github.com/jojoldu/springboot-rest-docs-spock)
- [Spring - REST Docs 적용 및 최적화하기](https://backtony.tistory.com/37)