### PR TITLE
Config: #76 Qodana에서 커스텀 불가능한 코드 커버리지 검사를 제거함

### DIFF
--- a/qodana.yaml
+++ b/qodana.yaml
@@ -13,3 +13,4 @@ exclude:
       - build.gradle
       - settings.gradle
   - name: CheckDependencyLicenses
+  - name: JvmCoverageInspection

--- a/src/test/java/com/growup/pms/test/IntegrationTestSupport.java
+++ b/src/test/java/com/growup/pms/test/IntegrationTestSupport.java
@@ -1,4 +1,4 @@
-package com.growup.pms;
+package com.growup.pms.test;
 
 import jakarta.transaction.Transactional;
 import org.springframework.boot.test.context.SpringBootTest;


### PR DESCRIPTION
## PR Type

- [x] **\[Config\]** ⚙ 환경설정을 변경했어요.
- [x] **\[Rename\]** 📁 폴더 및 파일의 이름을 변경했어요.

## Related Issues

- close #76 

## What does this PR do?

- [x] `JvmCoverageInspection`을 Qodana옵션에서 제외함
- [x] 일관성을 위해 테스트 서포트 클래스들을 한 패키지 아래로 이동시킴

## Other information

- 코드 커버리지를 강제하면 오히려 어중간에게 테스트가 터져서 코드 커버리지만을 채우기 위한 테스트 코드를 작성하게 되어 전체적인 테스트 코드 퀄리티가 떨어지는 경험을 했었던 것 같습니다. 그래서 팀원의 자율성에 맡기다가 계속해서 커버리지가 낮게 나온다고 생각이 들면 그때 커버리지를 강제해도 괜찮겠다는 생각이 들었습니다 :smile: 