### PR TITLE
Feat: #108 QueryDSL을 위한 기본 환경을 셋업함

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,6 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    // implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
     compileOnly 'org.projectlombok:lombok'
     testCompileOnly 'org.projectlombok:lombok'
     testAnnotationProcessor 'org.projectlombok:lombok'
@@ -50,6 +49,11 @@ dependencies {
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
     testImplementation 'com.epages:restdocs-api-spec-mockmvc:0.18.2'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
+    // QueryDSL
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
+    annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
+    annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
 }
 
 ext {
@@ -95,4 +99,8 @@ openapi3 {
     outputDirectory = 'src/main/resources/static/docs'
     tagDescriptionsPropertiesFile = 'src/docs/tag-descriptions.yaml'
     format = 'yaml'
+}
+
+compileJava {
+    options.compilerArgs << '-Aquerydsl.generatedAnnotationClass=com.querydsl.core.annotations.Generated'
 }

--- a/src/main/java/com/growup/pms/common/config/QueryDslConfig.java
+++ b/src/main/java/com/growup/pms/common/config/QueryDslConfig.java
@@ -1,0 +1,18 @@
+package com.growup.pms.common.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}


### PR DESCRIPTION
## PR Type

- [x] **\[Config\]** ⚙ 환경설정을 변경했어요.
- [x] **\[Chore\]** 🛒 빌드 프로세스 변경, 의존성 패키지 업데이트 했어요.

## Related Issues

- close #108 

## What does this PR do?

- [x] QueryDSL을 위한 의존성을 구성함
- [x] QueryDSL으로 자동 생성되는 QDomain.class를 커버리지 대상에서 제외함

## Other information

2.x에서는 `build.gradle`에서 설정해주어야 할 것들이 좀 있었던 것 같은데 3.x으로 오면서 설정이 간소화된 느낌이라 좋았습니다. 

### Jacoco에서 QDomain.class 제외하기
기존에는 아래와 같이 Q도메인 클래스를 제외하는 것 같습니다. 하지만 이 방법의 문제점은 자칫 잘못하면 QueryDSL 클래스가 아닌 다른 클래스도 함께 제외될 수 있다는 문제점이 있습니다.

```groovy
def QDomains = []

for (qPattern in '**/QA'..'**/QZ') {
	QDomains.add(qPattern + '*')
}
```

이 문제를 해결하려고 봤더니 [QueryDSL 공식 문서](http://querydsl.com/static/querydsl/latest/reference/html/ch03s03.html)에서 `querydsl.generatedAnnotationClass`를 확인할 수 있었습니다. 

Lombok과 비슷하게 자동으로 생성된 클래스(QDomain.class)에 `@Generated` 애노테이션을 붙여서 이를 Jacoco와 같은 정적 분석 도구에서 필터링을 할 수 있게끔 하는 방법인 것 같습니다(참고로, Jacoco는 0.8.2부터 애노테이션 이름이 `Generated`인 것이 클래스 레벨이나 메서드 레벨에 있으면 리포트 생성 중에 필터링됨).

```java
compileJava {
    options.compilerArgs << '-Aquerydsl.generatedAnnotationClass=com.querydsl.core.annotations.Generated'
}
```
## Reference
- [[Gradle] SpringBoot 3.x + QueryDSL 적용하기](https://velog.io/@kimsundae/Gradle-SpringBoot-3.x-QueryDSL-%EC%A0%81%EC%9A%A9%ED%95%98%EA%B8%B0)