### PR TITLE
Feat: #105 프로젝트 일정 조회 API 문서 작성

### DIFF
--- a/src/main/java/com/growup/pms/task/controller/TaskControllerV1.java
+++ b/src/main/java/com/growup/pms/task/controller/TaskControllerV1.java
@@ -48,12 +48,11 @@ public class TaskControllerV1 {
 
     @GetMapping
     @RequirePermission(PermissionType.PROJECT_TASK_READ)
-    public ResponseEntity<PageResponse<List<TaskResponse>>> getTasks(@PathVariable Long projectId,
-                                                                     @AuthenticationPrincipal SecurityUser user) {
+    public ResponseEntity<PageResponse<List<TaskResponse>>> getTasks(@PathVariable Long projectId) {
         log.debug("TaskControllerV1#getTasks called.");
         log.debug("projectId={}", projectId);
 
-        PageResponse<List<TaskResponse>> response = taskService.getTasks(projectId, user.getId());
+        PageResponse<List<TaskResponse>> response = taskService.getTasks(projectId);
         log.debug("PageResponse={}", response);
 
         return ResponseEntity.ok(response);

--- a/src/main/java/com/growup/pms/task/controller/TaskControllerV1.java
+++ b/src/main/java/com/growup/pms/task/controller/TaskControllerV1.java
@@ -28,7 +28,7 @@ public class TaskControllerV1 {
 
     @PostMapping
     @RequirePermission(PermissionType.PROJECT_STATUS_WRITE)
-    public ResponseEntity<TaskDetailResponse> createTask(@PathVariable("projectId") Integer projectId,
+    public ResponseEntity<TaskDetailResponse> createTask(@PathVariable Long projectId,
                                                          @AuthenticationPrincipal SecurityUser user,
                                                          @Valid @RequestBody TaskCreateRequest request) {
         log.debug("TaskControllerV1#createTask called.");

--- a/src/main/java/com/growup/pms/task/controller/TaskControllerV1.java
+++ b/src/main/java/com/growup/pms/task/controller/TaskControllerV1.java
@@ -58,4 +58,18 @@ public class TaskControllerV1 {
 
         return ResponseEntity.ok(response);
     }
+
+    @GetMapping("/{taskId}")
+    @RequirePermission(PermissionType.PROJECT_TASK_READ)
+    public ResponseEntity<TaskDetailResponse> getTask(@PathVariable Long projectId,
+                                                      @PathVariable Long taskId) {
+        log.debug("TaskControllerV1#getTask called.");
+        log.debug("projectId={}", projectId);
+        log.debug("taskId={}", taskId);
+
+        TaskDetailResponse response = taskService.getTask(projectId, taskId);
+        log.debug("response={}", response);
+
+        return ResponseEntity.ok(response);
+    }
 }

--- a/src/main/java/com/growup/pms/task/controller/TaskControllerV1.java
+++ b/src/main/java/com/growup/pms/task/controller/TaskControllerV1.java
@@ -3,15 +3,19 @@ package com.growup.pms.task.controller;
 import com.growup.pms.auth.domain.SecurityUser;
 import com.growup.pms.common.aop.annotation.RequirePermission;
 import com.growup.pms.role.domain.PermissionType;
+import com.growup.pms.status.controller.dto.response.PageResponse;
 import com.growup.pms.task.controller.dto.request.TaskCreateRequest;
 import com.growup.pms.task.controller.dto.response.TaskDetailResponse;
+import com.growup.pms.task.controller.dto.response.TaskResponse;
 import com.growup.pms.task.service.TaskService;
 import jakarta.validation.Valid;
 import java.net.URI;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -40,5 +44,18 @@ public class TaskControllerV1 {
         String uri = "/api/v1/project/" + projectId + "/task/" + response.getTaskId();
 
         return ResponseEntity.created(URI.create(uri)).body(response);
+    }
+
+    @GetMapping
+    @RequirePermission(PermissionType.PROJECT_TASK_READ)
+    public ResponseEntity<PageResponse<List<TaskResponse>>> getTasks(@PathVariable Long projectId,
+                                                                     @AuthenticationPrincipal SecurityUser user) {
+        log.debug("TaskControllerV1#getTasks called.");
+        log.debug("projectId={}", projectId);
+
+        PageResponse<List<TaskResponse>> response = taskService.getTasks(projectId, user.getId());
+        log.debug("PageResponse={}", response);
+
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/growup/pms/task/controller/dto/response/TaskResponse.java
+++ b/src/main/java/com/growup/pms/task/controller/dto/response/TaskResponse.java
@@ -1,0 +1,29 @@
+package com.growup.pms.task.controller.dto.response;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@ToString
+public class TaskResponse {
+
+    // 일정 PK, 상태 PK, 수행 회원 이름, 순서
+    private Long taskId;
+    private Long statusId;
+    private String taskName;
+    private String userNickname;
+    private Short sortOrder;
+
+    @Builder
+    public TaskResponse(Long taskId, Long statusId, String taskName, String userNickname, Short sortOrder) {
+        this.taskId = taskId;
+        this.statusId = statusId;
+        this.taskName = taskName;
+        this.userNickname = userNickname;
+        this.sortOrder = sortOrder;
+    }
+}

--- a/src/main/java/com/growup/pms/task/controller/dto/response/TaskResponse.java
+++ b/src/main/java/com/growup/pms/task/controller/dto/response/TaskResponse.java
@@ -11,7 +11,6 @@ import lombok.ToString;
 @ToString
 public class TaskResponse {
 
-    // 일정 PK, 상태 PK, 수행 회원 이름, 순서
     private Long taskId;
     private Long statusId;
     private String taskName;

--- a/src/main/java/com/growup/pms/task/service/TaskService.java
+++ b/src/main/java/com/growup/pms/task/service/TaskService.java
@@ -1,7 +1,10 @@
 package com.growup.pms.task.service;
 
+import com.growup.pms.status.controller.dto.response.PageResponse;
 import com.growup.pms.task.controller.dto.response.TaskDetailResponse;
+import com.growup.pms.task.controller.dto.response.TaskResponse;
 import com.growup.pms.task.service.dto.TaskCreateDto;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -14,6 +17,10 @@ import org.springframework.transaction.annotation.Transactional;
 public class TaskService {
 
     public TaskDetailResponse createTask(TaskCreateDto dto) {
+        return null;
+    }
+
+    public PageResponse<List<TaskResponse>> getTasks(Long projectId, Long userId) {
         return null;
     }
 }

--- a/src/main/java/com/growup/pms/task/service/TaskService.java
+++ b/src/main/java/com/growup/pms/task/service/TaskService.java
@@ -20,7 +20,7 @@ public class TaskService {
         return null;
     }
 
-    public PageResponse<List<TaskResponse>> getTasks(Long projectId, Long userId) {
+    public PageResponse<List<TaskResponse>> getTasks(Long projectId) {
         return null;
     }
 

--- a/src/main/java/com/growup/pms/task/service/TaskService.java
+++ b/src/main/java/com/growup/pms/task/service/TaskService.java
@@ -23,4 +23,8 @@ public class TaskService {
     public PageResponse<List<TaskResponse>> getTasks(Long projectId, Long userId) {
         return null;
     }
+
+    public TaskDetailResponse getTask(Long projectId, Long taskId) {
+        return null;
+    }
 }

--- a/src/main/resources/static/docs/openapi3.yaml
+++ b/src/main/resources/static/docs/openapi3.yaml
@@ -503,6 +503,46 @@ paths:
       responses:
         "204":
           description: "204"
+  /api/v1/project/{projectId}/task/{taskId}:
+    get:
+      tags:
+      - Task
+      summary: 프로젝트 일정 전체 조회
+      description: 프로젝트 내의 모든 일정을 조회합니다.
+      operationId: task-controller-v1-docs-test/일정_상세조회_api_문서를_생성한다
+      parameters:
+      - name: projectId
+        in: path
+        description: 조회할 프로젝트 식별자
+        required: true
+        schema:
+          type: number
+      - name: taskId
+        in: path
+        description: 조회할 일정 식별자
+        required: true
+        schema:
+          type: number
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/api-v1-project-projectId-task-106941217'
+              examples:
+                task-controller-v1-docs-test/일정_상세조회_api_문서를_생성한다:
+                  value: |-
+                    {
+                      "taskId" : 1,
+                      "statusId" : 1,
+                      "userNickname" : "Hello나는팀원1",
+                      "taskName" : "환경설정 마치기",
+                      "content" : "# GU-PMS 에 필요한 환경 설정은 다음과 같습니다. <br> ## 목차 <br> ### 1. JPA 의존성 주입",
+                      "sortOrder" : 1,
+                      "startDate" : "2023-01-01",
+                      "endDate" : "2023-12-31"
+                    }
   /api/v1/team/{teamId}/invitation/accept:
     post:
       tags:

--- a/src/main/resources/static/docs/openapi3.yaml
+++ b/src/main/resources/static/docs/openapi3.yaml
@@ -507,8 +507,8 @@ paths:
     get:
       tags:
       - Task
-      summary: 프로젝트 일정 전체 조회
-      description: 프로젝트 내의 모든 일정을 조회합니다.
+      summary: 프로젝트 일정 상세 조회
+      description: 프로젝트 내에서 선택한 일정을 조회합니다.
       operationId: task-controller-v1-docs-test/일정_상세조회_api_문서를_생성한다
       parameters:
       - name: projectId

--- a/src/main/resources/static/docs/openapi3.yaml
+++ b/src/main/resources/static/docs/openapi3.yaml
@@ -269,6 +269,45 @@ paths:
                       "sortOrder" : 0
                     }
   /api/v1/project/{projectId}/task:
+    get:
+      tags:
+      - Task
+      summary: 프로젝트 일정 전체 조회
+      description: 프로젝트 내의 모든 일정을 조회합니다.
+      operationId: task-controller-v1-docs-test/일정_전체조회_api_문서를_생성한다
+      parameters:
+      - name: projectId
+        in: path
+        description: 조회할 프로젝트 식별자
+        required: true
+        schema:
+          type: number
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/api-v1-project-projectId-task1816323921'
+              examples:
+                task-controller-v1-docs-test/일정_전체조회_api_문서를_생성한다:
+                  value: |-
+                    {
+                      "hasNext" : false,
+                      "items" : [ {
+                        "taskId" : 1,
+                        "statusId" : 1,
+                        "taskName" : "환경설정 마치기",
+                        "userNickname" : "Hello나는팀원1",
+                        "sortOrder" : 1
+                      }, {
+                        "taskId" : 2,
+                        "statusId" : 1,
+                        "taskName" : "프로젝트 일정 등록 기능 구현",
+                        "userNickname" : "Hello2",
+                        "sortOrder" : 1
+                      } ]
+                    }
     post:
       tags:
       - Task
@@ -571,6 +610,33 @@ components:
         colorCode:
           type: string
           description: 색상 코드
+    api-v1-project-projectId-task1816323921:
+      type: object
+      properties:
+        hasNext:
+          type: boolean
+          description: 다음 페이지 존재 여부
+        items:
+          type: array
+          description: 프로젝트 내에 존재하는 일정 목록
+          items:
+            type: object
+            properties:
+              statusId:
+                type: number
+                description: 프로젝트 상태 식별자
+              sortOrder:
+                type: number
+                description: 정렬 순서
+              userNickname:
+                type: string
+                description: 회원 이름
+              taskName:
+                type: string
+                description: 일정 이름
+              taskId:
+                type: number
+                description: 프로젝트 일정 식별자
     api-v1-team-id666486821:
       type: object
       properties:

--- a/src/test/java/com/growup/pms/docs/TaskControllerV1DocsTest.java
+++ b/src/test/java/com/growup/pms/docs/TaskControllerV1DocsTest.java
@@ -114,7 +114,6 @@ public class TaskControllerV1DocsTest extends ControllerSliceTestSupport {
     }
 
     @Test
-    @WithMockSecurityUser
     void 일정_전체조회_API_문서를_생성한다() throws Exception {
         // given
         Long 예상_프로젝트_식별자 = 1L;
@@ -128,7 +127,7 @@ public class TaskControllerV1DocsTest extends ControllerSliceTestSupport {
         PageResponse<List<TaskResponse>> response = PageResponse.of(false, List.of(response1, response2));
 
         // when
-        when(taskService.getTasks(anyLong(), anyLong())).thenReturn(response);
+        when(taskService.getTasks(anyLong())).thenReturn(response);
 
         // then
         mockMvc.perform(get(("/api/v1/project/{projectId}/task"), 예상_프로젝트_식별자)
@@ -181,8 +180,8 @@ public class TaskControllerV1DocsTest extends ControllerSliceTestSupport {
                 .andDo(docs.document(resource(
                         ResourceSnippetParameters.builder()
                                 .tag(TAG)
-                                .summary("프로젝트 일정 전체 조회")
-                                .description("프로젝트 내의 모든 일정을 조회합니다.")
+                                .summary("프로젝트 일정 상세 조회")
+                                .description("프로젝트 내에서 선택한 일정을 조회합니다.")
                                 .pathParameters(
                                         parameterWithName("projectId").type(SimpleType.NUMBER)
                                                 .description("조회할 프로젝트 식별자"),

--- a/src/test/java/com/growup/pms/docs/TaskControllerV1DocsTest.java
+++ b/src/test/java/com/growup/pms/docs/TaskControllerV1DocsTest.java
@@ -4,7 +4,9 @@ import static com.epages.restdocs.apispec.ResourceDocumentation.headerWithName;
 import static com.epages.restdocs.apispec.ResourceDocumentation.parameterWithName;
 import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
@@ -12,15 +14,19 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.epages.restdocs.apispec.SimpleType;
+import com.growup.pms.status.controller.dto.response.PageResponse;
 import com.growup.pms.task.controller.dto.request.TaskCreateRequest;
 import com.growup.pms.task.controller.dto.response.TaskDetailResponse;
+import com.growup.pms.task.controller.dto.response.TaskResponse;
 import com.growup.pms.task.service.TaskService;
 import com.growup.pms.task.service.dto.TaskCreateDto;
 import com.growup.pms.test.annotation.AutoKoreanDisplayName;
 import com.growup.pms.test.annotation.WithMockSecurityUser;
 import com.growup.pms.test.fixture.task.TaskCreateRequestTestBuilder;
 import com.growup.pms.test.fixture.task.TaskDetailResponseTestBuilder;
+import com.growup.pms.test.fixture.task.TaskResponseTestBuilder;
 import com.growup.pms.test.support.ControllerSliceTestSupport;
+import java.util.List;
 import org.apache.http.HttpHeaders;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -105,5 +111,56 @@ public class TaskControllerV1DocsTest extends ControllerSliceTestSupport {
                                         headerWithName(org.springframework.http.HttpHeaders.LOCATION).description(
                                                 "생성된 일정의 URL"))
                                 .build())));
+    }
+
+    @Test
+    @WithMockSecurityUser
+    void 일정_전체조회_API_문서를_생성한다() throws Exception {
+        // given
+        Long 예상_프로젝트_식별자 = 1L;
+        TaskResponse response1 = TaskResponseTestBuilder.일정_전체조회_응답은().이다();
+        TaskResponse response2 = TaskResponseTestBuilder.일정_전체조회_응답은()
+                .일정_식별자는(2L)
+                .일정이름은("프로젝트 일정 등록 기능 구현")
+                .회원_닉네임은("Hello2")
+                .이다();
+
+        PageResponse<List<TaskResponse>> response = PageResponse.of(false, List.of(response1, response2));
+
+        // when
+        when(taskService.getTasks(anyLong(), anyLong())).thenReturn(response);
+
+        // then
+        mockMvc.perform(get(("/api/v1/project/{projectId}/task"), 예상_프로젝트_식별자)
+                        .header(org.springframework.http.HttpHeaders.AUTHORIZATION, "Bearer 액세스 토큰"))
+                .andExpect(status().isOk())
+                .andDo(docs.document(resource(
+                        ResourceSnippetParameters.builder()
+                                .tag(TAG)
+                                .summary("프로젝트 일정 전체 조회")
+                                .description("프로젝트 내의 모든 일정을 조회합니다.")
+                                .pathParameters(
+                                        parameterWithName("projectId").type(SimpleType.NUMBER)
+                                                .description("조회할 프로젝트 식별자")
+                                )
+                                .responseFields(
+                                        fieldWithPath("hasNext").type(JsonFieldType.BOOLEAN)
+                                                .description("다음 페이지 존재 여부"),
+                                        fieldWithPath("items").type(JsonFieldType.ARRAY)
+                                                .description("프로젝트 내에 존재하는 일정 목록"),
+                                        fieldWithPath("items[].taskId").type(JsonFieldType.NUMBER)
+                                                .description("프로젝트 일정 식별자"),
+                                        fieldWithPath("items[].statusId").type(JsonFieldType.NUMBER)
+                                                .description("프로젝트 상태 식별자"),
+                                        fieldWithPath("items[].userNickname").type(JsonFieldType.STRING)
+                                                .description("회원 이름"),
+                                        fieldWithPath("items[].taskName").type(JsonFieldType.STRING)
+                                                .description("일정 이름"),
+                                        fieldWithPath("items[].sortOrder").type(JsonFieldType.NUMBER)
+                                                .description("정렬 순서")
+                                )
+                                .build()
+                )));
+
     }
 }

--- a/src/test/java/com/growup/pms/docs/TaskControllerV1DocsTest.java
+++ b/src/test/java/com/growup/pms/docs/TaskControllerV1DocsTest.java
@@ -163,4 +163,52 @@ public class TaskControllerV1DocsTest extends ControllerSliceTestSupport {
                 )));
 
     }
+
+    @Test
+    void 일정_상세조회_API_문서를_생성한다() throws Exception {
+        // given
+        Long 예상_프로젝트_식별자 = 1L;
+        Long 예상_일정_식별자 = 1L;
+        TaskDetailResponse 예상_상세조회_응답 = TaskDetailResponseTestBuilder.일정_상세조회_응답은().이다();
+
+        // when
+        when(taskService.getTask(anyLong(), anyLong())).thenReturn(예상_상세조회_응답);
+
+        // then
+        mockMvc.perform(get(("/api/v1/project/{projectId}/task/{taskId}"), 예상_프로젝트_식별자, 예상_일정_식별자)
+                        .header(org.springframework.http.HttpHeaders.AUTHORIZATION, "Bearer 액세스 토큰"))
+                .andExpect(status().isOk())
+                .andDo(docs.document(resource(
+                        ResourceSnippetParameters.builder()
+                                .tag(TAG)
+                                .summary("프로젝트 일정 전체 조회")
+                                .description("프로젝트 내의 모든 일정을 조회합니다.")
+                                .pathParameters(
+                                        parameterWithName("projectId").type(SimpleType.NUMBER)
+                                                .description("조회할 프로젝트 식별자"),
+                                        parameterWithName("taskId").type(SimpleType.NUMBER)
+                                                .description("조회할 일정 식별자")
+                                )
+                                .responseFields(
+                                        fieldWithPath("taskId").type(JsonFieldType.NUMBER)
+                                                .description("프로젝트 일정 식별자"),
+                                        fieldWithPath("statusId").type(JsonFieldType.NUMBER)
+                                                .description("프로젝트 상태 식별자"),
+                                        fieldWithPath("userNickname").type(JsonFieldType.STRING)
+                                                .description("회원 이름"),
+                                        fieldWithPath("taskName").type(JsonFieldType.STRING)
+                                                .description("일정 이름"),
+                                        fieldWithPath("content").type(JsonFieldType.STRING)
+                                                .description("일정 내용"),
+                                        fieldWithPath("sortOrder").type(JsonFieldType.NUMBER)
+                                                .description("정렬 순서"),
+                                        fieldWithPath("startDate").type(JsonFieldType.STRING)
+                                                .description("시작일자"),
+                                        fieldWithPath("endDate").type(JsonFieldType.STRING)
+                                                .description("종료일자")
+                                )
+                                .build()
+                )));
+
+    }
 }

--- a/src/test/java/com/growup/pms/test/fixture/task/TaskResponseTestBuilder.java
+++ b/src/test/java/com/growup/pms/test/fixture/task/TaskResponseTestBuilder.java
@@ -1,0 +1,57 @@
+package com.growup.pms.test.fixture.task;
+
+import com.growup.pms.task.controller.dto.response.TaskResponse;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+
+@SuppressWarnings("NonAsciiCharacters")
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class TaskResponseTestBuilder {
+
+    private Long taskId = 1L;
+    private Long statusId = 1L;
+    private String userNickname = "Hello나는팀원1";
+    private String taskName = "환경설정 마치기";
+    private Short sortOrder = 1;
+
+    public static TaskResponseTestBuilder 일정_전체조회_응답은() {
+        return new TaskResponseTestBuilder();
+    }
+
+    public TaskResponseTestBuilder 일정_식별자는(Long taskId) {
+        this.taskId = taskId;
+        return this;
+    }
+
+    public TaskResponseTestBuilder 상태_식별자는(Long statusId) {
+        this.statusId = statusId;
+        return this;
+    }
+
+    public TaskResponseTestBuilder 회원_닉네임은(String userNickname) {
+        this.userNickname = userNickname;
+        return this;
+    }
+
+    public TaskResponseTestBuilder 일정이름은(String taskName) {
+        this.taskName = taskName;
+        return this;
+    }
+
+    public TaskResponseTestBuilder 정렬순서는(Short sortOrder) {
+        this.sortOrder = sortOrder;
+        return this;
+    }
+
+    public TaskResponse 이다() {
+        return TaskResponse.builder()
+                .taskId(taskId)
+                .statusId(statusId)
+                .userNickname(userNickname)
+                .taskName(taskName)
+                .sortOrder(sortOrder)
+                .build();
+    }
+}


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

<!-- 'x'를 이용하여 이 PR에 적용되는 항목을 확인해 주세요. -->

- [x] **\[Refactor\]** 🛠 리팩토링을 했어요 (기능적인 변화 없이, api 변경 없이)
- [x] **\[Docs\]** 📝 문서 내용을 변경했어요.
- [x] **\[Test\]** 🧪 테스트 코드를 추가/삭제/변경 했어요.
- [x] **\[Comment\]** 🖋 필요한 주석 추가/삭제/변경 했어요.

## Related Issues

<!--#을 눌러 이슈와 연결해 주세요-->

## What does this PR do?
- close #105 
<!--무엇을 하셨나요?-->

- [x] 프로젝트 일정 목록 조회 API 스켈레톤 코드 작성
- [x]  프로젝트 일정 목록 조회 API 문서 작성
- [x]  프로젝트 일정 상세 조회 API 스켈레톤 코드 작성
- [x]  프로젝트 일정 상세 조회 API 문서 작성

## Other information

<!--참고한 자료, 추가적인 사항, 기타 의견-->
- 현재 전체 조회 API 들의 경우 `PageResponse` 를 사용해서 커서 기반 페이지네이션을 구현하게 될 예정인데, 이 부분에 대해서 계속 이런식으로 사용하는 것이 나을지를 논의하고 싶습니다. Jira 를 사용했을 때를 생각해보면 따로 읽기 갯수 제한을 두지 않고 그냥 전부 다 읽어오는게 바람직할 것 같긴합니다. 수정에는 큰 시간이 필요하지 않을 것 같습니다. (권한 인가 수정 사항을 반영하면서 적용하면 될 것 같습니다 😎)
- 일정 전체 조회의 경우, 상태별로 FE 단에서 다시 이를 분리를 해야할 것 같은데, 해당 작업을 BE 단에서 미리 처리해서 내보내야 할지도 논의하고 싶습니다. 뼈대를 만들고 생각해보니, 이런식으로 상태에 필터가 걸리는 응답의 경우는 FE 단에서 처리하는 것보다 BE 단에서의 처리가 훠어어얼씬 더 빠르다는 피드백을 받은 경험이 있습니다 😅