### PR TITLE
Feat: #139 프로젝트 상태 목록 조회 기능 구현

### DIFF
--- a/src/main/java/com/growup/pms/status/controller/StatusControllerV1.java
+++ b/src/main/java/com/growup/pms/status/controller/StatusControllerV1.java
@@ -5,7 +5,6 @@ import com.growup.pms.common.aop.annotation.RequirePermission;
 import com.growup.pms.role.domain.PermissionType;
 import com.growup.pms.status.controller.dto.request.StatusCreateRequest;
 import com.growup.pms.status.controller.dto.request.StatusEditRequest;
-import com.growup.pms.status.controller.dto.response.PageResponse;
 import com.growup.pms.status.controller.dto.response.StatusResponse;
 import com.growup.pms.status.service.StatusService;
 import jakarta.validation.Valid;
@@ -48,11 +47,12 @@ public class StatusControllerV1 {
 
 
     @GetMapping
-    public ResponseEntity<PageResponse<List<StatusResponse>>> getStatuses(@PathVariable Long projectId) {
+    @RequirePermission(PermissionType.PROJECT_STATUS_READ)
+    public ResponseEntity<List<StatusResponse>> getStatuses(@PathVariable Long projectId) {
         log.debug("StatusControllerV1#getStatuses called.");
         log.debug("projectId={}", projectId);
 
-        PageResponse<List<StatusResponse>> response = statusService.getStatuses(projectId);
+        List<StatusResponse> response = statusService.getStatuses(projectId);
         log.debug("response={}", response);
 
         return ResponseEntity.ok(response);

--- a/src/main/java/com/growup/pms/status/repository/StatusQueryRepository.java
+++ b/src/main/java/com/growup/pms/status/repository/StatusQueryRepository.java
@@ -1,0 +1,13 @@
+package com.growup.pms.status.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class StatusQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+}

--- a/src/main/java/com/growup/pms/status/repository/StatusQueryRepository.java
+++ b/src/main/java/com/growup/pms/status/repository/StatusQueryRepository.java
@@ -1,13 +1,9 @@
 package com.growup.pms.status.repository;
 
-import com.querydsl.jpa.impl.JPAQueryFactory;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Repository;
+import com.growup.pms.status.controller.dto.response.StatusResponse;
+import java.util.List;
 
-@Repository
-@RequiredArgsConstructor
-public class StatusQueryRepository {
+public interface StatusQueryRepository {
 
-    private final JPAQueryFactory queryFactory;
-
+    List<StatusResponse> getAllStatusByProjectId(Long projectId);
 }

--- a/src/main/java/com/growup/pms/status/repository/StatusQueryRepositoryImpl.java
+++ b/src/main/java/com/growup/pms/status/repository/StatusQueryRepositoryImpl.java
@@ -1,0 +1,56 @@
+package com.growup.pms.status.repository;
+
+import static com.growup.pms.status.domain.QStatus.status;
+
+import com.growup.pms.status.controller.dto.response.StatusResponse;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Repository;
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class StatusQueryRepositoryImpl implements StatusQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    public List<StatusResponse> getAllStatusByProjectId(Long projectId) {
+        List<Long> ids = queryFactory
+                .select(status.id)
+                .from(status)
+                .where(
+                        isProjectId(projectId)
+                )
+                .fetch();
+
+        log.info("ids={}", ids);
+
+        if (ids == null || ids.isEmpty()) {
+            return new ArrayList<>();
+        }
+
+        return queryFactory
+                .select(Projections.constructor(StatusResponse.class,
+                        status.id,
+                        status.project.id,
+                        status.name,
+                        status.colorCode,
+                        status.sortOrder
+                ))
+                .from(status)
+                .where(
+                        status.id.in(ids)
+                )
+                .orderBy(status.sortOrder.asc())
+                .fetch();
+    }
+
+    private BooleanExpression isProjectId(Long projectId) {
+        return projectId != null ? status.project.id.eq(projectId) : null;
+    }
+}

--- a/src/main/java/com/growup/pms/status/repository/StatusRepository.java
+++ b/src/main/java/com/growup/pms/status/repository/StatusRepository.java
@@ -5,6 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface StatusRepository extends JpaRepository<Status, Long> {
+public interface StatusRepository extends JpaRepository<Status, Long>, StatusQueryRepository {
 
 }

--- a/src/main/java/com/growup/pms/status/service/StatusService.java
+++ b/src/main/java/com/growup/pms/status/service/StatusService.java
@@ -33,7 +33,7 @@ public class StatusService {
     }
 
     public List<StatusResponse> getStatuses(Long projectId) {
-        return null;
+        return statusRepository.getAllStatusByProjectId(projectId);
     }
 
     public void editStatus(StatusEditCommand dto) {

--- a/src/main/java/com/growup/pms/status/service/StatusService.java
+++ b/src/main/java/com/growup/pms/status/service/StatusService.java
@@ -4,7 +4,6 @@ import com.growup.pms.common.exception.code.ErrorCode;
 import com.growup.pms.common.exception.exceptions.EntityNotFoundException;
 import com.growup.pms.project.domain.Project;
 import com.growup.pms.project.repository.ProjectRepository;
-import com.growup.pms.status.controller.dto.response.PageResponse;
 import com.growup.pms.status.controller.dto.response.StatusResponse;
 import com.growup.pms.status.domain.Status;
 import com.growup.pms.status.repository.StatusRepository;
@@ -33,7 +32,7 @@ public class StatusService {
         return StatusResponse.of(savedStatus);
     }
 
-    public PageResponse<List<StatusResponse>> getStatuses(Long projectId) {
+    public List<StatusResponse> getStatuses(Long projectId) {
         return null;
     }
 

--- a/src/main/java/com/growup/pms/task/controller/TaskControllerV1.java
+++ b/src/main/java/com/growup/pms/task/controller/TaskControllerV1.java
@@ -3,7 +3,6 @@ package com.growup.pms.task.controller;
 import com.growup.pms.auth.domain.SecurityUser;
 import com.growup.pms.common.aop.annotation.RequirePermission;
 import com.growup.pms.role.domain.PermissionType;
-import com.growup.pms.status.controller.dto.response.PageResponse;
 import com.growup.pms.task.controller.dto.request.TaskCreateRequest;
 import com.growup.pms.task.controller.dto.request.TaskEditRequest;
 import com.growup.pms.task.controller.dto.response.TaskDetailResponse;
@@ -54,14 +53,14 @@ public class TaskControllerV1 {
 
     @GetMapping
     @RequirePermission(PermissionType.PROJECT_TASK_READ)
-    public ResponseEntity<PageResponse<List<TaskResponse>>> getTasks(@PathVariable Long projectId) {
+    public ResponseEntity<List<TaskResponse>> getTasks(@PathVariable Long projectId) {
         log.debug("TaskControllerV1#getTasks called.");
         log.debug("projectId={}", projectId);
 
-        PageResponse<List<TaskResponse>> response = taskService.getTasks(projectId);
-        log.debug("PageResponse={}", response);
+        List<TaskResponse> responses = taskService.getTasks(projectId);
+        log.debug("PageResponse={}", responses);
 
-        return ResponseEntity.ok(response);
+        return ResponseEntity.ok(responses);
     }
 
     @GetMapping("/{taskId}")

--- a/src/main/java/com/growup/pms/task/service/TaskService.java
+++ b/src/main/java/com/growup/pms/task/service/TaskService.java
@@ -1,6 +1,5 @@
 package com.growup.pms.task.service;
 
-import com.growup.pms.status.controller.dto.response.PageResponse;
 import com.growup.pms.task.controller.dto.response.TaskDetailResponse;
 import com.growup.pms.task.controller.dto.response.TaskResponse;
 import com.growup.pms.task.service.dto.TaskCreateCommand;
@@ -21,7 +20,7 @@ public class TaskService {
         return null;
     }
 
-    public PageResponse<List<TaskResponse>> getTasks(Long projectId) {
+    public List<TaskResponse> getTasks(Long projectId) {
         return null;
     }
 

--- a/src/main/resources/static/docs/openapi3.yaml
+++ b/src/main/resources/static/docs/openapi3.yaml
@@ -24,7 +24,7 @@ paths:
       tags:
       - Team
       summary: 팀 생성
-      description: "사용자가 새로운 팀을 생성합니다. 생성 시, 다른 사용자를 함께 팀으로 초대할 수 있습니다."
+      description: 팀을 생성합니다.
       operationId: team-controller-v1-docs-test/팀_생성_api_문서를_생성한다사용자가_팀을_생성_시에/성공한다
       parameters:
       - name: Content-Type
@@ -40,6 +40,12 @@ paths:
             schema:
               $ref: '#/components/schemas/api-v1-team2045834793'
             examples:
+              사용자가_팀을_생성_시에/성공한다:
+                value: |-
+                  {
+                    "name" : "구구구",
+                    "content" : "안녕하세요, 구구구입니다!"
+                  }
               team-controller-v1-docs-test/팀_생성_api_문서를_생성한다:
                 value: |-
                   {
@@ -50,12 +56,6 @@ paths:
                       "id" : 2,
                       "role" : "Mate"
                     } ]
-                  }
-              사용자가_팀을_생성_시에/성공한다:
-                value: |-
-                  {
-                    "name" : "구구구",
-                    "content" : "안녕하세요, 구구구입니다!"
                   }
       responses:
         "201":
@@ -70,7 +70,7 @@ paths:
       tags:
       - Team
       summary: 팀 조회
-      description: 해당 팀 정보를 조회합니다.
+      description: 팀 정보를 조회합니다.
       operationId: team-controller-v1-docs-test/팀_조회_api_문서를_생성한다사용자가_팀을_조회_시에/성공한다
       parameters:
       - name: id
@@ -78,8 +78,7 @@ paths:
         description: 팀 아이디
         required: true
         schema:
-          type: integer
-          format: int32
+          type: string
       responses:
         "200":
           description: "200"
@@ -93,6 +92,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/api-v1-team-id-1408924108'
               examples:
+                사용자가_팀을_조회_시에/성공한다:
+                  value: |-
+                    {
+                      "name" : "구구구",
+                      "content" : "안녕하세요, 구구구입니다!"
+                    }
                 team-controller-v1-docs-test/팀_조회_api_문서를_생성한다:
                   value: |-
                     {
@@ -100,17 +105,11 @@ paths:
                       "content" : "코드 한 줄에 커피 한 잔, 우리는 카페인으로 움직이는 팀입니다!",
                       "creatorId" : 1
                     }
-                사용자가_팀을_조회_시에/성공한다:
-                  value: |-
-                    {
-                      "name" : "구구구",
-                      "content" : "안녕하세요, 구구구입니다!"
-                    }
     delete:
       tags:
       - Team
       summary: 팀 제거
-      description: 해당 팀을 제거합니다.
+      description: 팀을 제거합니다.
       operationId: team-controller-v1-docs-test/팀_제거_api_문서를_생성한다사용자가_팀을_제거_시에/성공한다
       parameters:
       - name: id
@@ -118,8 +117,7 @@ paths:
         description: 제거할 팀 ID
         required: true
         schema:
-          type: integer
-          format: int32
+          type: string
       responses:
         "204":
           description: "204"
@@ -184,12 +182,12 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/api-v1-user-login-434021498'
+              $ref: '#/components/schemas/api-v1-user-login-1192987719'
             examples:
               사용자가_로그인_시에/성공한다:
                 value: |-
                   {
-                    "username" : "brown",
+                    "email" : "brown@gu99.com",
                     "password" : "test1234!@#$"
                   }
               login-controller-v1-docs-test/로그인_api_문서를_생성한다:
@@ -230,26 +228,23 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/api-v1-project-projectId-status1840086195'
+                $ref: '#/components/schemas/api-v1-project-projectId-status1220278061'
               examples:
                 status-controller-v1-docs-test/상태_목록조회_api_문서를_생성한다:
                   value: |-
-                    {
-                      "hasNext" : false,
-                      "items" : [ {
-                        "statusId" : 1,
-                        "projectId" : 1,
-                        "name" : "대기중",
-                        "colorCode" : "FFFFFF",
-                        "sortOrder" : 0
-                      }, {
-                        "statusId" : 2,
-                        "projectId" : 1,
-                        "name" : "진행중",
-                        "colorCode" : "FFFFF0",
-                        "sortOrder" : 1
-                      } ]
-                    }
+                    [ {
+                      "statusId" : 1,
+                      "projectId" : 1,
+                      "name" : "대기중",
+                      "colorCode" : "FFFFFF",
+                      "sortOrder" : 0
+                    }, {
+                      "statusId" : 2,
+                      "projectId" : 1,
+                      "name" : "진행중",
+                      "colorCode" : "FFFFF0",
+                      "sortOrder" : 1
+                    } ]
     post:
       tags:
       - Status
@@ -325,26 +320,23 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/api-v1-project-projectId-task1816323921'
+                $ref: '#/components/schemas/api-v1-project-projectId-task1608277617'
               examples:
                 task-controller-v1-docs-test/일정_전체조회_api_문서를_생성한다:
                   value: |-
-                    {
-                      "hasNext" : false,
-                      "items" : [ {
-                        "taskId" : 1,
-                        "statusId" : 1,
-                        "taskName" : "환경설정 마치기",
-                        "userNickname" : "Hello나는팀원1",
-                        "sortOrder" : 1
-                      }, {
-                        "taskId" : 2,
-                        "statusId" : 1,
-                        "taskName" : "프로젝트 일정 등록 기능 구현",
-                        "userNickname" : "Hello2",
-                        "sortOrder" : 1
-                      } ]
-                    }
+                    [ {
+                      "taskId" : 1,
+                      "statusId" : 1,
+                      "taskName" : "환경설정 마치기",
+                      "userNickname" : "Hello나는팀원1",
+                      "sortOrder" : 1
+                    }, {
+                      "taskId" : 2,
+                      "statusId" : 1,
+                      "taskName" : "프로젝트 일정 등록 기능 구현",
+                      "userNickname" : "Hello2",
+                      "sortOrder" : 1
+                    } ]
     post:
       tags:
       - Task
@@ -736,12 +728,12 @@ components:
     api-v1-team-id-1408924108:
       type: object
       properties:
-        name:
-          type: string
-          description: 팀 이름
         creatorId:
           type: number
           description: 팀 생성자 ID
+        name:
+          type: string
+          description: 팀 이름
         content:
           type: string
           description: 팀 소개
@@ -757,48 +749,29 @@ components:
         colorCode:
           type: string
           description: 색상 코드
-    api-v1-project-projectId-task1816323921:
-      type: object
-      properties:
-        hasNext:
-          type: boolean
-          description: 다음 페이지 존재 여부
-        items:
-          type: array
-          description: 프로젝트 내에 존재하는 일정 목록
-          items:
-            type: object
-            properties:
-              statusId:
-                type: number
-                description: 프로젝트 상태 식별자
-              sortOrder:
-                type: number
-                description: 정렬 순서
-              userNickname:
-                type: string
-                description: 회원 이름
-              taskName:
-                type: string
-                description: 일정 이름
-              taskId:
-                type: number
-                description: 프로젝트 일정 식별자
-    api-v1-user-login-434021498:
-      type: object
-      properties:
-        password:
-          type: string
-          description: 비밀번호
-        username:
-          type: string
-          description: 아이디
+    api-v1-project-projectId-status1220278061:
+      type: array
+      items:
+        type: object
+        properties:
+          statusId:
+            type: number
+            description: 상태 식별자
+          sortOrder:
+            type: number
+            description: 정렬 순서
+          name:
+            type: string
+            description: 상태 이름
+          colorCode:
+            type: string
+            description: 색상 코드
+          projectId:
+            type: number
+            description: 프로젝트 식별자
     api-v1-team2045834793:
       type: object
       properties:
-        name:
-          type: string
-          description: 팀 이름
         coworkers:
           type: array
           description: 초대된 사용자 목록
@@ -814,6 +787,9 @@ components:
         creatorId:
           type: number
           description: 팀 생성자 ID
+        name:
+          type: string
+          description: 팀 이름
         content:
           type: string
           description: 팀 소개
@@ -826,33 +802,38 @@ components:
         content:
           type: string
           description: 팀 소개
-    api-v1-project-projectId-status1840086195:
+    api-v1-user-login-1192987719:
       type: object
       properties:
-        hasNext:
-          type: boolean
-          description: 다음 페이지 존재 여부
-        items:
-          type: array
-          description: 프로젝트 내에 존재하는 상태 목록
-          items:
-            type: object
-            properties:
-              statusId:
-                type: number
-                description: 상태 식별자
-              sortOrder:
-                type: number
-                description: 정렬 순서
-              name:
-                type: string
-                description: 상태 이름
-              colorCode:
-                type: string
-                description: 색상 코드
-              projectId:
-                type: number
-                description: 프로젝트 식별자
+        password:
+          type: string
+          description: 비밀번호
+        email:
+          type: string
+          description: 이메일
+        username:
+          type: string
+          description: 아이디
+    api-v1-project-projectId-task1608277617:
+      type: array
+      items:
+        type: object
+        properties:
+          statusId:
+            type: number
+            description: 프로젝트 상태 식별자
+          sortOrder:
+            type: number
+            description: 정렬 순서
+          userNickname:
+            type: string
+            description: 회원 이름
+          taskName:
+            type: string
+            description: 일정 이름
+          taskId:
+            type: number
+            description: 프로젝트 일정 식별자
     api-v1-project-projectId-task-taskId581167037:
       type: object
       properties:

--- a/src/test/java/com/growup/pms/docs/StatusControllerV1DocsTest.java
+++ b/src/test/java/com/growup/pms/docs/StatusControllerV1DocsTest.java
@@ -19,7 +19,6 @@ import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.epages.restdocs.apispec.SimpleType;
 import com.growup.pms.status.controller.dto.request.StatusCreateRequest;
 import com.growup.pms.status.controller.dto.request.StatusEditRequest;
-import com.growup.pms.status.controller.dto.response.PageResponse;
 import com.growup.pms.status.controller.dto.response.StatusResponse;
 import com.growup.pms.status.service.StatusService;
 import com.growup.pms.status.service.dto.StatusCreateCommand;
@@ -110,11 +109,10 @@ public class StatusControllerV1DocsTest extends ControllerSliceTestSupport {
                 .정렬순서는((short) 1)
                 .이다();
 
-        List<StatusResponse> statusResponses = List.of(statusResponse1, statusResponse2);
-        PageResponse<List<StatusResponse>> response = PageResponse.of(false, statusResponses);
+        List<StatusResponse> responses = List.of(statusResponse1, statusResponse2);
 
         when(statusService.getStatuses(조회할_프로젝트_ID))
-                .thenReturn(response);
+                .thenReturn(responses);
 
         // when & then
         mockMvc.perform(get("/api/v1/project/{projectId}/status", 조회할_프로젝트_ID)
@@ -130,19 +128,15 @@ public class StatusControllerV1DocsTest extends ControllerSliceTestSupport {
                                                 .description("조회할 프로젝트 식별자")
                                 )
                                 .responseFields(
-                                        fieldWithPath("hasNext").type(JsonFieldType.BOOLEAN)
-                                                .description("다음 페이지 존재 여부"),
-                                        fieldWithPath("items").type(JsonFieldType.ARRAY)
-                                                .description("프로젝트 내에 존재하는 상태 목록"),
-                                        fieldWithPath("items[].statusId").type(JsonFieldType.NUMBER)
+                                        fieldWithPath("[].statusId").type(JsonFieldType.NUMBER)
                                                 .description("상태 식별자"),
-                                        fieldWithPath("items[].projectId").type(JsonFieldType.NUMBER)
+                                        fieldWithPath("[].projectId").type(JsonFieldType.NUMBER)
                                                 .description("프로젝트 식별자"),
-                                        fieldWithPath("items[].name").type(JsonFieldType.STRING)
+                                        fieldWithPath("[].name").type(JsonFieldType.STRING)
                                                 .description("상태 이름"),
-                                        fieldWithPath("items[].colorCode").type(JsonFieldType.STRING)
+                                        fieldWithPath("[].colorCode").type(JsonFieldType.STRING)
                                                 .description("색상 코드"),
-                                        fieldWithPath("items[].sortOrder").type(JsonFieldType.NUMBER)
+                                        fieldWithPath("[].sortOrder").type(JsonFieldType.NUMBER)
                                                 .description("정렬 순서")
                                 )
                                 .build()

--- a/src/test/java/com/growup/pms/docs/TaskControllerV1DocsTest.java
+++ b/src/test/java/com/growup/pms/docs/TaskControllerV1DocsTest.java
@@ -19,7 +19,6 @@ import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.epages.restdocs.apispec.SimpleType;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import com.growup.pms.status.controller.dto.response.PageResponse;
 import com.growup.pms.task.controller.dto.request.TaskCreateRequest;
 import com.growup.pms.task.controller.dto.request.TaskEditRequest;
 import com.growup.pms.task.controller.dto.response.TaskDetailResponse;
@@ -136,10 +135,10 @@ public class TaskControllerV1DocsTest extends ControllerSliceTestSupport {
                 .회원_닉네임은("Hello2")
                 .이다();
 
-        PageResponse<List<TaskResponse>> response = PageResponse.of(false, List.of(response1, response2));
+        List<TaskResponse> responses = List.of(response1, response2);
 
         // when
-        when(taskService.getTasks(anyLong())).thenReturn(response);
+        when(taskService.getTasks(anyLong())).thenReturn(responses);
 
         // then
         mockMvc.perform(get(("/api/v1/project/{projectId}/task"), 예상_프로젝트_식별자)
@@ -155,19 +154,15 @@ public class TaskControllerV1DocsTest extends ControllerSliceTestSupport {
                                                 .description("조회할 프로젝트 식별자")
                                 )
                                 .responseFields(
-                                        fieldWithPath("hasNext").type(JsonFieldType.BOOLEAN)
-                                                .description("다음 페이지 존재 여부"),
-                                        fieldWithPath("items").type(JsonFieldType.ARRAY)
-                                                .description("프로젝트 내에 존재하는 일정 목록"),
-                                        fieldWithPath("items[].taskId").type(JsonFieldType.NUMBER)
+                                        fieldWithPath("[].taskId").type(JsonFieldType.NUMBER)
                                                 .description("프로젝트 일정 식별자"),
-                                        fieldWithPath("items[].statusId").type(JsonFieldType.NUMBER)
+                                        fieldWithPath("[].statusId").type(JsonFieldType.NUMBER)
                                                 .description("프로젝트 상태 식별자"),
-                                        fieldWithPath("items[].userNickname").type(JsonFieldType.STRING)
+                                        fieldWithPath("[].userNickname").type(JsonFieldType.STRING)
                                                 .description("회원 이름"),
-                                        fieldWithPath("items[].taskName").type(JsonFieldType.STRING)
+                                        fieldWithPath("[].taskName").type(JsonFieldType.STRING)
                                                 .description("일정 이름"),
-                                        fieldWithPath("items[].sortOrder").type(JsonFieldType.NUMBER)
+                                        fieldWithPath("[].sortOrder").type(JsonFieldType.NUMBER)
                                                 .description("정렬 순서")
                                 )
                                 .build()

--- a/src/test/java/com/growup/pms/status/repository/StatusQueryRepositoryImplTest.java
+++ b/src/test/java/com/growup/pms/status/repository/StatusQueryRepositoryImplTest.java
@@ -1,0 +1,141 @@
+package com.growup.pms.status.repository;
+
+
+import static com.growup.pms.test.fixture.project.ProjectTestBuilder.프로젝트는;
+import static com.growup.pms.test.fixture.status.StatusTestBuilder.상태는;
+import static com.growup.pms.test.fixture.team.TeamTestBuilder.팀은;
+import static com.growup.pms.test.fixture.user.UserTestBuilder.사용자는;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.growup.pms.project.domain.Project;
+import com.growup.pms.project.repository.ProjectRepository;
+import com.growup.pms.status.controller.dto.response.StatusResponse;
+import com.growup.pms.status.domain.Status;
+import com.growup.pms.team.domain.Team;
+import com.growup.pms.team.repository.TeamRepository;
+import com.growup.pms.test.annotation.AutoKoreanDisplayName;
+import com.growup.pms.test.support.RepositoryTestSupport;
+import com.growup.pms.user.domain.User;
+import com.growup.pms.user.repository.UserRepository;
+import jakarta.transaction.Transactional;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@Transactional
+@AutoKoreanDisplayName
+@SuppressWarnings("NonAsciiCharacters")
+class StatusQueryRepositoryImplTest extends RepositoryTestSupport {
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    TeamRepository teamRepository;
+
+    @Autowired
+    ProjectRepository projectRepository;
+
+    @Autowired
+    StatusRepository statusRepository;
+
+    @Autowired
+    StatusQueryRepositoryImpl statusQueryRepository;
+
+    User 브라운, 레니, 레너드;
+    Team GU팀, 게시판팀;
+    Project PMS_프로젝트, 게시판_프로젝트;
+    Status PMS_할일, PMS_진행중, PMS_완료;
+
+    @BeforeEach
+    void setUp() {
+        브라운 = userRepository.save(사용자는().식별자가(1L).아이디가("brown").닉네임이("브라운").이다());
+        레니 = userRepository.save(사용자는().식별자가(2L).아이디가("lenny").닉네임이("레니").이다());
+        레너드 = userRepository.save(사용자는().식별자가(3L).아이디가("leonard").닉네임이("레너드").이다());
+
+        GU팀 = teamRepository.save(팀은().식별자가(1L).이름이("GU팀").팀장이(브라운).이다());
+        게시판팀 = teamRepository.save(팀은().식별자가(2L).이름이("게시판팀").팀장이(레니).이다());
+
+        PMS_프로젝트 = projectRepository.save(
+                프로젝트는().식별자가(1L)
+                        .이름이("PMS 프로젝트")
+                        .설명이("프로젝트 관리 서비스를 개발하는 프로젝트.  상태가 있습니다.")
+                        .팀이(GU팀)
+                        .시작일이(LocalDate.of(2024, 1, 1))
+                        .종료일이(LocalDate.of(2024, 12, 31))
+                        .이다()
+        );
+
+        게시판_프로젝트 = projectRepository.save(
+                프로젝트는()
+                        .식별자가(2L)
+                        .이름이("게시판 프로젝트")
+                        .설명이("게시판을 개발하는 프로젝트. 상태가 없습니다.")
+                        .팀이(게시판팀)
+                        .시작일이(LocalDate.of(2023, 1, 1))
+                        .종료일이(LocalDate.of(2023, 12, 31))
+                        .이다()
+        );
+
+        PMS_할일 = statusRepository.save(
+                상태는().식별자가(1L)
+                        .프로젝트가(PMS_프로젝트)
+                        .이름이("할일")
+                        .색상코드가("345678")
+                        .정렬순서가((short) 1)
+                        .이다()
+        );
+
+        PMS_진행중 = statusRepository.save(
+                상태는().식별자가(2L)
+                        .프로젝트가(PMS_프로젝트)
+                        .이름이("진행중")
+                        .색상코드가("B4FF3B")
+                        .정렬순서가((short) 2)
+                        .이다()
+        );
+
+        PMS_완료 = statusRepository.save(
+                상태는().식별자가(3L)
+                        .프로젝트가(PMS_프로젝트)
+                        .이름이("완료")
+                        .색상코드가("A03FFF")
+                        .정렬순서가((short) 3)
+                        .이다()
+        );
+    }
+
+    @Nested
+    class 전체_상태_검색시 {
+
+        @Test
+        void 성공한다() {
+            // given
+            Long 프로젝트_ID = PMS_프로젝트.getId();
+
+            // when
+            List<StatusResponse> 실제_결과 = statusQueryRepository.getAllStatusByProjectId(프로젝트_ID);
+
+            // then
+            assertThat(실제_결과).hasSize(3);
+            System.out.println(실제_결과);
+            assertThat(실제_결과.stream().map(StatusResponse::name))
+                    .containsExactlyInAnyOrder("할일", "진행중", "완료");
+        }
+
+        @Test
+        void 프로젝트에_상태가_없으면_빈_리스트를_반환한다() {
+            // given
+            Long 프로젝트_ID = 게시판_프로젝트.getId();
+
+            // when
+            List<StatusResponse> 실졔_결과 = statusQueryRepository.getAllStatusByProjectId(프로젝트_ID);
+
+            // then
+            assertThat(실졔_결과).isEmpty();
+        }
+    }
+}

--- a/src/test/java/com/growup/pms/status/service/StatusServiceTest.java
+++ b/src/test/java/com/growup/pms/status/service/StatusServiceTest.java
@@ -2,6 +2,7 @@ package com.growup.pms.status.service;
 
 import static com.growup.pms.test.fixture.project.ProjectTestBuilder.프로젝트는;
 import static com.growup.pms.test.fixture.status.StatusCreateRequestTestBuilder.상태_생성_요청은;
+import static com.growup.pms.test.fixture.status.StatusResponseTestBuilder.상태_응답은;
 import static com.growup.pms.test.fixture.status.StatusTestBuilder.상태는;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -16,6 +17,8 @@ import com.growup.pms.status.domain.Status;
 import com.growup.pms.status.repository.StatusRepository;
 import com.growup.pms.status.service.dto.StatusCreateCommand;
 import com.growup.pms.test.annotation.AutoKoreanDisplayName;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -69,6 +72,62 @@ class StatusServiceTest {
             // when & then
             assertThatThrownBy(() -> statusService.createStatus(상태_생성_요청))
                     .isInstanceOf(EntityNotFoundException.class);
+        }
+    }
+
+    @Nested
+    class 사용자가_프로젝트_상태_전체조회시에 {
+
+        @Test
+        void 성공한다() {
+            // given
+            Long 예상_프로젝트_ID = 1L;
+            StatusResponse 예상_응답1 = 상태_응답은().상태_식별자는(1L)
+                    .프로젝트_식별자는(예상_프로젝트_ID)
+                    .이름은("할일")
+                    .색상코드는("345678")
+                    .정렬순서는((short) 1)
+                    .이다();
+
+            StatusResponse 예상_응답2 = 상태_응답은().상태_식별자는(2L)
+                    .프로젝트_식별자는(예상_프로젝트_ID)
+                    .이름은("진행중")
+                    .색상코드는("B4FF3B")
+                    .정렬순서는((short) 2)
+                    .이다();
+
+            StatusResponse 예상_응답3 = 상태_응답은().상태_식별자는(3L)
+                    .프로젝트_식별자는(예상_프로젝트_ID)
+                    .이름은("완료")
+                    .색상코드는("A03FFF")
+                    .정렬순서는((short) 3)
+                    .이다();
+
+            List<StatusResponse> 예상_결과 = List.of(예상_응답1, 예상_응답2, 예상_응답3);
+            when(statusRepository.getAllStatusByProjectId(예상_프로젝트_ID))
+                    .thenReturn(예상_결과);
+
+            // when
+            List<StatusResponse> 실제_결과 = statusService.getStatuses(예상_프로젝트_ID);
+
+            // then
+            assertThat(실제_결과).isEqualTo(예상_결과);
+        }
+
+        @Test
+        void 프로젝트에_상태가_없다면_빈_리스트를_반환한다() {
+            // given
+            Long 예상_프로젝트_ID = 1L;
+            List<StatusResponse> 예상_결과 = new ArrayList<>();
+
+            when(statusRepository.getAllStatusByProjectId(예상_프로젝트_ID))
+                    .thenReturn(예상_결과);
+
+            // when
+            List<StatusResponse> 실제_결과 = statusService.getStatuses(예상_프로젝트_ID);
+
+            // then
+            assertThat(실제_결과).isEqualTo(예상_결과);
         }
     }
 }


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

<!-- 'x'를 이용하여 이 PR에 적용되는 항목을 확인해 주세요. -->

- [x] **\[Feat\]** 🎨 새로운 기능을 추가했어요.
- [x] **\[Test\]** 🧪 테스트 코드를 추가/삭제/변경 했어요.

## Related Issues

<!--#을 눌러 이 슈와 연결해 주세요-->

## What does this PR do?
- close #139

<!--무엇을 하셨나요?-->

 - [x] PageResponse 클래스 삭제 (회의 결과 반영)
 - [x] 상태 조회 레포지토리 생성
 - [x] 프로젝트 식별키를 통한 프로젝트 상태 전체 조회 쿼리 작성
 - [x] 프로젝트 식별키를 통한 프로젝트 상태 전체 조회 쿼리 테스트 작성
 - [x] 프로젝트 상태 전체 조회 기능 구현
 - [x] 프로젝트 상태 전체 조회 테스트 작성


## Other information

<!--참고한 자료, 추가적인 사항, 기타 의견-->
- 최초 구현 시, `@DataJpaTest` 에서 QueryDSL 클래스의 빈 주입에 실패하는 상황이 발생했습니다.
  - 이유는 `@DataJpaTest` 의 다음과 같은 특징 때문이었습니다. `@Repository` 로 등록했다고 해서 스캔을 하는 것이 아니라, JPA에 관련된 설정들만 적용한다는 것 입니다.
  - 그래서 조회 레포지토리 구현을 최초 구현한 방법이 아닌, 프래그먼트 인터페이스를 확장하는 방식으로 구현하였고, 해결하였습니다.
  - 아래는 해당 참조 링크들입니다.
    - [커스텀 레포지토리 구현 - Spring 문서](https://docs.spring.io/spring-data/jpa/reference/repositories/custom-implementations.html)
    - [DataJpaTest 에서 QueryDSL 을 통해 구현한 `@Repository` 테스트하기](https://rachel0115.tistory.com/entry/QueryDsl-DataJpaTest-%EC%97%90%EC%84%9C-Repository-%ED%85%8C%EC%8A%A4%ED%8A%B8%ED%95%98%EA%B8%B0)