### PR TITLE
Refactor: #143 API 변경사항 반영

### DIFF
--- a/qodana.yaml
+++ b/qodana.yaml
@@ -1,5 +1,5 @@
 version: 1.0
-linter: jetbrains/qodana-jvm:latest
+linter: jetbrains/qodana-jvm-community:latest
 profile:
   name: qodana.recommended
 projectJDK: "21"

--- a/src/main/java/com/growup/pms/task/controller/TaskControllerV1.java
+++ b/src/main/java/com/growup/pms/task/controller/TaskControllerV1.java
@@ -23,6 +23,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.util.UriComponentsBuilder;
 
@@ -54,11 +55,12 @@ public class TaskControllerV1 {
 
     @GetMapping
     @RequirePermission(PermissionType.PROJECT_TASK_READ)
-    public ResponseEntity<List<TaskResponse>> getTasks(@ProjectId @PathVariable Long projectId) {
+    public ResponseEntity<List<TaskResponse>> getTasks(@ProjectId @PathVariable Long projectId,
+                                                       @RequestParam(required = false, defaultValue = "0") Long statusId) {
         log.debug("TaskControllerV1#getTasks called.");
         log.debug("projectId={}", projectId);
 
-        List<TaskResponse> responses = taskService.getTasks(projectId);
+        List<TaskResponse> responses = taskService.getTasks(projectId, statusId);
         log.debug("PageResponse={}", responses);
 
         return ResponseEntity.ok(responses);

--- a/src/main/java/com/growup/pms/task/controller/TaskControllerV1.java
+++ b/src/main/java/com/growup/pms/task/controller/TaskControllerV1.java
@@ -1,6 +1,7 @@
 package com.growup.pms.task.controller;
 
 import com.growup.pms.auth.domain.SecurityUser;
+import com.growup.pms.common.aop.annotation.ProjectId;
 import com.growup.pms.common.aop.annotation.RequirePermission;
 import com.growup.pms.role.domain.PermissionType;
 import com.growup.pms.task.controller.dto.request.TaskCreateRequest;
@@ -35,7 +36,7 @@ public class TaskControllerV1 {
 
     @PostMapping
     @RequirePermission(PermissionType.PROJECT_STATUS_WRITE)
-    public ResponseEntity<TaskDetailResponse> createTask(@PathVariable Long projectId,
+    public ResponseEntity<TaskDetailResponse> createTask(@ProjectId @PathVariable Long projectId,
                                                          @AuthenticationPrincipal SecurityUser user,
                                                          @Valid @RequestBody TaskCreateRequest request) {
         log.debug("TaskControllerV1#createTask called.");
@@ -53,7 +54,7 @@ public class TaskControllerV1 {
 
     @GetMapping
     @RequirePermission(PermissionType.PROJECT_TASK_READ)
-    public ResponseEntity<List<TaskResponse>> getTasks(@PathVariable Long projectId) {
+    public ResponseEntity<List<TaskResponse>> getTasks(@ProjectId @PathVariable Long projectId) {
         log.debug("TaskControllerV1#getTasks called.");
         log.debug("projectId={}", projectId);
 
@@ -65,7 +66,7 @@ public class TaskControllerV1 {
 
     @GetMapping("/{taskId}")
     @RequirePermission(PermissionType.PROJECT_TASK_READ)
-    public ResponseEntity<TaskDetailResponse> getTask(@PathVariable Long projectId,
+    public ResponseEntity<TaskDetailResponse> getTask(@ProjectId @PathVariable Long projectId,
                                                       @PathVariable Long taskId) {
         log.debug("TaskControllerV1#getTask called.");
         log.debug("projectId={}", projectId);
@@ -79,7 +80,7 @@ public class TaskControllerV1 {
 
     @PatchMapping("/{taskId}")
     @RequirePermission(PermissionType.PROJECT_TASK_WRITE)
-    public ResponseEntity<Void> editTask(@PathVariable Long projectId, @PathVariable Long taskId,
+    public ResponseEntity<Void> editTask(@ProjectId @PathVariable Long projectId, @PathVariable Long taskId,
                                          @AuthenticationPrincipal SecurityUser user,
                                          @Valid @RequestBody TaskEditRequest request) {
         log.debug("TaskControllerV1#editTask called.");
@@ -94,7 +95,7 @@ public class TaskControllerV1 {
 
     @DeleteMapping("/{taskId}")
     @RequirePermission(PermissionType.PROJECT_TASK_DELETE)
-    public ResponseEntity<Void> deleteTask(@PathVariable Long projectId, @PathVariable Long taskId) {
+    public ResponseEntity<Void> deleteTask(@ProjectId @PathVariable Long projectId, @PathVariable Long taskId) {
         log.debug("TaskControllerV1#deleteTask called.");
         log.debug("projectId={}", projectId);
         log.debug("taskId={}", taskId);

--- a/src/main/java/com/growup/pms/task/controller/dto/request/TaskCreateRequest.java
+++ b/src/main/java/com/growup/pms/task/controller/dto/request/TaskCreateRequest.java
@@ -1,5 +1,6 @@
 package com.growup.pms.task.controller.dto.request;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.growup.pms.task.service.dto.TaskCreateCommand;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -7,7 +8,6 @@ import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.Size;
 import java.time.LocalDate;
 import lombok.Builder;
-import org.springframework.format.annotation.DateTimeFormat;
 
 @Builder
 public record TaskCreateRequest(
@@ -24,10 +24,10 @@ public record TaskCreateRequest(
         @Positive
         Short sortOrder,
 
-        @DateTimeFormat(pattern = "yyyy-MM-dd")
+        @JsonFormat(pattern = "yyyy-MM-dd")
         LocalDate startDate,
 
-        @DateTimeFormat(pattern = "yyyy-MM-dd")
+        @JsonFormat(pattern = "yyyy-MM-dd")
         LocalDate endDate
 ) {
     public TaskCreateCommand toCommand(Long userId) {

--- a/src/main/java/com/growup/pms/task/controller/dto/request/TaskEditRequest.java
+++ b/src/main/java/com/growup/pms/task/controller/dto/request/TaskEditRequest.java
@@ -1,5 +1,6 @@
 package com.growup.pms.task.controller.dto.request;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.growup.pms.task.service.dto.TaskEditCommand;
 import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.Size;
@@ -10,7 +11,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import org.openapitools.jackson.nullable.JsonNullable;
-import org.springframework.format.annotation.DateTimeFormat;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
@@ -27,10 +27,10 @@ public class TaskEditRequest {
     @Positive
     private JsonNullable<Short> sortOrder = JsonNullable.undefined();
 
-    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    @JsonFormat(pattern = "yyyy-MM-dd")
     private JsonNullable<LocalDate> startDate = JsonNullable.undefined();
 
-    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    @JsonFormat(pattern = "yyyy-MM-dd")
     private JsonNullable<LocalDate> endDate = JsonNullable.undefined();
 
     @Builder

--- a/src/main/java/com/growup/pms/task/service/TaskService.java
+++ b/src/main/java/com/growup/pms/task/service/TaskService.java
@@ -20,7 +20,7 @@ public class TaskService {
         return null;
     }
 
-    public List<TaskResponse> getTasks(Long projectId) {
+    public List<TaskResponse> getTasks(Long projectId, Long statusId) {
         return null;
     }
 

--- a/src/main/resources/static/docs/openapi3.yaml
+++ b/src/main/resources/static/docs/openapi3.yaml
@@ -333,13 +333,19 @@ paths:
     get:
       tags:
       - Task
-      summary: 프로젝트 일정 전체 조회
-      description: 프로젝트 내의 모든 일정을 조회합니다.
+      summary: 상태별 프로젝트 일정 전체 조회
+      description: 프로젝트와 상태의 식별자를 사용하여 프로젝트 내의 모든 일정을 상태별로 조회합니다.
       operationId: task-controller-v1-docs-test/일정_전체조회_api_문서를_생성한다
       parameters:
       - name: projectId
         in: path
         description: 조회할 프로젝트 식별자
+        required: true
+        schema:
+          type: number
+      - name: statusId
+        in: query
+        description: 조회할 상태 식별자
         required: true
         schema:
           type: number
@@ -730,15 +736,26 @@ components:
         colorCode:
           type: string
           description: 변경할 색상 코드
-    api-v1-user-login-434021498:
-      type: object
-      properties:
-        password:
-          type: string
-          description: 비밀번호
-        username:
-          type: string
-          description: 아이디
+    api-v1-project-projectId-task1608277617:
+      type: array
+      items:
+        type: object
+        properties:
+          statusId:
+            type: number
+            description: 프로젝트 상태 식별자
+          sortOrder:
+            type: number
+            description: 정렬 순서
+          userNickname:
+            type: string
+            description: 회원 이름
+          taskName:
+            type: string
+            description: 일정 이름
+          taskId:
+            type: number
+            description: 프로젝트 일정 식별자
     api-v1-team-teamId-invitation-1361275252:
       type: object
       properties:
@@ -787,33 +804,6 @@ components:
         colorCode:
           type: string
           description: 색상 코드
-    api-v1-project-projectId-task1816323921:
-      type: object
-      properties:
-        hasNext:
-          type: boolean
-          description: 다음 페이지 존재 여부
-        items:
-          type: array
-          description: 프로젝트 내에 존재하는 일정 목록
-          items:
-            type: object
-            properties:
-              statusId:
-                type: number
-                description: 프로젝트 상태 식별자
-              sortOrder:
-                type: number
-                description: 정렬 순서
-              userNickname:
-                type: string
-                description: 회원 이름
-              taskName:
-                type: string
-                description: 일정 이름
-              taskId:
-                type: number
-                description: 프로젝트 일정 식별자
     api-v1-project-projectId-status1220278061:
       type: array
       items:
@@ -879,26 +869,6 @@ components:
         username:
           type: string
           description: 아이디
-    api-v1-project-projectId-task1608277617:
-      type: array
-      items:
-        type: object
-        properties:
-          statusId:
-            type: number
-            description: 프로젝트 상태 식별자
-          sortOrder:
-            type: number
-            description: 정렬 순서
-          userNickname:
-            type: string
-            description: 회원 이름
-          taskName:
-            type: string
-            description: 일정 이름
-          taskId:
-            type: number
-            description: 프로젝트 일정 식별자
     api-v1-project-projectId-task-taskId581167037:
       type: object
       properties:

--- a/src/test/java/com/growup/pms/docs/TaskControllerV1DocsTest.java
+++ b/src/test/java/com/growup/pms/docs/TaskControllerV1DocsTest.java
@@ -128,6 +128,7 @@ public class TaskControllerV1DocsTest extends ControllerSliceTestSupport {
     void 일정_전체조회_API_문서를_생성한다() throws Exception {
         // given
         Long 예상_프로젝트_식별자 = 1L;
+        Long 예상_상태_식별자 = 1L;
         TaskResponse response1 = TaskResponseTestBuilder.일정_전체조회_응답은().이다();
         TaskResponse response2 = TaskResponseTestBuilder.일정_전체조회_응답은()
                 .일정_식별자는(2L)
@@ -138,20 +139,26 @@ public class TaskControllerV1DocsTest extends ControllerSliceTestSupport {
         List<TaskResponse> responses = List.of(response1, response2);
 
         // when
-        when(taskService.getTasks(anyLong())).thenReturn(responses);
+        when(taskService.getTasks(anyLong(), anyLong())).thenReturn(responses);
 
         // then
         mockMvc.perform(get(("/api/v1/project/{projectId}/task"), 예상_프로젝트_식별자)
-                        .header(org.springframework.http.HttpHeaders.AUTHORIZATION, "Bearer 액세스 토큰"))
+                        .header(org.springframework.http.HttpHeaders.AUTHORIZATION, "Bearer 액세스 토큰")
+                        .queryParam("statusId", String.valueOf(예상_상태_식별자))
+                )
                 .andExpect(status().isOk())
                 .andDo(docs.document(resource(
                         ResourceSnippetParameters.builder()
                                 .tag(TAG)
-                                .summary("프로젝트 일정 전체 조회")
-                                .description("프로젝트 내의 모든 일정을 조회합니다.")
+                                .summary("상태별 프로젝트 일정 전체 조회")
+                                .description("프로젝트와 상태의 식별자를 사용하여 프로젝트 내의 모든 일정을 상태별로 조회합니다.")
                                 .pathParameters(
                                         parameterWithName("projectId").type(SimpleType.NUMBER)
                                                 .description("조회할 프로젝트 식별자")
+                                )
+                                .queryParameters(
+                                        parameterWithName("statusId").type(SimpleType.NUMBER)
+                                                .description("조회할 상태 식별자")
                                 )
                                 .responseFields(
                                         fieldWithPath("[].taskId").type(JsonFieldType.NUMBER)


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

<!-- 'x'를 이용하여 이 PR에 적용되는 항목을 확인해 주세요. -->

- [x] **\[Refactor\]** 🛠 리팩토링을 했어요 (기능적인 변화 없이, api 변경 없이)
- [x] **\[Test\]** 🧪 테스트 코드를 추가/삭제/변경 했어요.

## Related Issues

<!--#을 눌러 이슈와 연결해 주세요-->
- close #143 
## What does this PR do?

<!--무엇을 하셨나요?-->

- [x] 일정 목록 조회 API 수정
- [x] 일정 목록 조회 API 문서 수정
- [x] LocalDate 타입 validation 수정

## Other information

<!--참고한 자료, 추가적인 사항, 기타 의견-->
전에 논의가 되었던, 프로젝트의 일정을 상태별로 조회하는 부분에 대한 수정은 다음과 같이 진행되었습니다.
- 먼저 단순하게, API를 여러번 호출하여 전체 일정을 조회하도록 수정했습니다.
- 상태의 PK 를 통해 해당 상태의 목록을 조회해서 상태의 개수 만큼 조회 API 를 호출하는 방법으로 구현했습니다.
- 이렇게 수정한 이유는, 프로젝트별로 상태가 동적이기 때문입니다. 어떤 프로젝트는 3개의 상태를 가지는 반면, 어떤 프로젝트는 5개의 상태를 가질 수 있기 때문입니다.
- 따라서 현재 제가 생각한 방법은 이렇게 API를 여러번 호출하는 것입니다. 다른 좋은 의견이 있다면 즉각 반영하도록 하겠습니다!