### PR TITLE
Feat: #167 이메일 인증 코드를 전송하는 기능을 구현함

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,8 @@ dependencies {
     annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
     annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
     annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 ext {

--- a/src/main/java/com/growup/pms/auth/domain/RefreshToken.java
+++ b/src/main/java/com/growup/pms/auth/domain/RefreshToken.java
@@ -11,7 +11,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
-import java.time.Instant;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -38,17 +38,17 @@ public class RefreshToken extends BaseEntity {
     private String token;
 
     @Column(nullable = false)
-    private Instant expiryDate;
+    private LocalDateTime expiredAt;
 
     @Builder
-    public RefreshToken(User user, String token, Instant expiryDate) {
+    public RefreshToken(User user, String token, LocalDateTime expiryDate) {
         this.user = user;
         this.token = token;
-        this.expiryDate = expiryDate;
+        this.expiredAt = expiryDate;
     }
 
-    public void updateToken(String newToken, Instant newExpiryDate) {
+    public void renewToken(String newToken, LocalDateTime newExpiryDate) {
         this.token = newToken;
-        this.expiryDate = newExpiryDate;
+        this.expiredAt = newExpiryDate;
     }
 }

--- a/src/main/java/com/growup/pms/auth/service/EmailVerificationService.java
+++ b/src/main/java/com/growup/pms/auth/service/EmailVerificationService.java
@@ -1,0 +1,50 @@
+package com.growup.pms.auth.service;
+
+import com.growup.pms.auth.service.dto.EmailDetails;
+import java.time.Duration;
+import java.util.concurrent.ThreadLocalRandom;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+@Service
+@RequiredArgsConstructor
+public class EmailVerificationService {
+    public static final String KEYSPACE_USER_EMAIL_CODE = "user:%s:email";
+    public static final Duration VERIFICATION_CODE_EXPIRATION = Duration.ofSeconds(60);
+    public static final int MAX_VERIFICATION_CODE = 999999;
+
+    private final MailtrapClient mailtrapClient;
+    private final StringRedisTemplate stringRedisTemplate;
+
+    public boolean verifyEmail(String email, String code) {
+        String value = stringRedisTemplate.opsForValue().get(KEYSPACE_USER_EMAIL_CODE.formatted(email));
+        return StringUtils.hasLength(value) && value.equals(code);
+    }
+
+    public String getAndSetVerificationCode(String email) {
+        String verificationCode = generateVerificationCode();
+
+        stringRedisTemplate.opsForValue().set(KEYSPACE_USER_EMAIL_CODE.formatted(email), verificationCode,
+                VERIFICATION_CODE_EXPIRATION);
+        mailtrapClient.sendEmail(EmailDetails.builder()
+                .recipient(email)
+                .subject("인증 코드 안내 - [서비스 이름]")
+                .content("""
+                    안녕하세요,
+                    
+                    아래의 인증 코드를 사용하여 이메일 주소를 인증해 주세요:
+                    
+                    인증 코드: %s
+                    
+                    이 코드는 %d초 후에 만료됩니다.
+                    """.formatted(verificationCode, VERIFICATION_CODE_EXPIRATION.getSeconds()))
+                .build());
+        return verificationCode;
+    }
+
+    private String generateVerificationCode() {
+        return "%06d".formatted(ThreadLocalRandom.current().nextInt(MAX_VERIFICATION_CODE));
+    }
+}

--- a/src/main/java/com/growup/pms/auth/service/EmailVerificationService.java
+++ b/src/main/java/com/growup/pms/auth/service/EmailVerificationService.java
@@ -1,6 +1,7 @@
 package com.growup.pms.auth.service;
 
 import com.growup.pms.auth.service.dto.EmailDetails;
+import com.growup.pms.auth.service.mail.MailClient;
 import java.time.Duration;
 import java.util.concurrent.ThreadLocalRandom;
 import lombok.RequiredArgsConstructor;
@@ -15,7 +16,7 @@ public class EmailVerificationService {
     public static final Duration VERIFICATION_CODE_EXPIRATION = Duration.ofSeconds(60);
     public static final int MAX_VERIFICATION_CODE = 999999;
 
-    private final MailtrapClient mailtrapClient;
+    private final MailClient mailClient;
     private final StringRedisTemplate stringRedisTemplate;
 
     public boolean verifyEmail(String email, String code) {
@@ -28,7 +29,7 @@ public class EmailVerificationService {
 
         stringRedisTemplate.opsForValue().set(KEYSPACE_USER_EMAIL_CODE.formatted(email), verificationCode,
                 VERIFICATION_CODE_EXPIRATION);
-        mailtrapClient.sendEmail(EmailDetails.builder()
+        mailClient.sendEmail(EmailDetails.builder()
                 .recipient(email)
                 .subject("인증 코드 안내 - [서비스 이름]")
                 .content("""

--- a/src/main/java/com/growup/pms/auth/service/MailtrapClient.java
+++ b/src/main/java/com/growup/pms/auth/service/MailtrapClient.java
@@ -1,0 +1,38 @@
+package com.growup.pms.auth.service;
+
+import com.growup.pms.auth.service.dto.EmailDetails;
+import com.growup.pms.common.exception.code.ErrorCode;
+import com.growup.pms.common.exception.exceptions.MessageFailureException;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+
+@Service
+public class MailtrapClient {
+    private final JavaMailSender mailSender;
+    private final String sandboxSenderEmail;
+
+    public MailtrapClient(JavaMailSender mailSender, @Value("${mailtrap.from}") String sandboxSenderEmail) {
+        this.mailSender = mailSender;
+        this.sandboxSenderEmail = sandboxSenderEmail;
+    }
+
+    public void sendEmail(EmailDetails emailDetails) {
+        try {
+            MimeMessage message = mailSender.createMimeMessage();
+            MimeMessageHelper helper = new MimeMessageHelper(message);
+
+            helper.setFrom(sandboxSenderEmail);
+            helper.setTo(emailDetails.recipient());
+            helper.setSubject(emailDetails.subject());
+            helper.setText(emailDetails.content());
+
+            mailSender.send(message);
+        } catch (MessagingException e) {
+            throw new MessageFailureException(ErrorCode.EMAIL_SENDING_ERROR);
+        }
+    }
+}

--- a/src/main/java/com/growup/pms/auth/service/dto/EmailDetails.java
+++ b/src/main/java/com/growup/pms/auth/service/dto/EmailDetails.java
@@ -1,0 +1,7 @@
+package com.growup.pms.auth.service.dto;
+
+import lombok.Builder;
+
+@Builder
+public record EmailDetails(String recipient, String subject, String content) {
+}

--- a/src/main/java/com/growup/pms/auth/service/mail/MailClient.java
+++ b/src/main/java/com/growup/pms/auth/service/mail/MailClient.java
@@ -1,0 +1,7 @@
+package com.growup.pms.auth.service.mail;
+
+import com.growup.pms.auth.service.dto.EmailDetails;
+
+public interface MailClient {
+    void sendEmail(EmailDetails emailDetails);
+}

--- a/src/main/java/com/growup/pms/auth/service/mail/MailtrapClient.java
+++ b/src/main/java/com/growup/pms/auth/service/mail/MailtrapClient.java
@@ -1,4 +1,4 @@
-package com.growup.pms.auth.service;
+package com.growup.pms.auth.service.mail;
 
 import com.growup.pms.auth.service.dto.EmailDetails;
 import com.growup.pms.common.exception.code.ErrorCode;
@@ -6,12 +6,13 @@ import com.growup.pms.common.exception.exceptions.MessageFailureException;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.MailException;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Service;
 
 @Service
-public class MailtrapClient {
+public class MailtrapClient implements MailClient {
     private final JavaMailSender mailSender;
     private final String sandboxSenderEmail;
 
@@ -31,7 +32,7 @@ public class MailtrapClient {
             helper.setText(emailDetails.content());
 
             mailSender.send(message);
-        } catch (MessagingException e) {
+        } catch (MessagingException | MailException e) {
             throw new MessageFailureException(ErrorCode.EMAIL_SENDING_ERROR);
         }
     }

--- a/src/main/java/com/growup/pms/common/config/RedisConfig.java
+++ b/src/main/java/com/growup/pms/common/config/RedisConfig.java
@@ -1,0 +1,33 @@
+package com.growup.pms.common.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+
+@Configuration
+@EnableRedisRepositories
+public class RedisConfig {
+    private final String host;
+    private final int port;
+
+    public RedisConfig(@Value("${spring.data.redis.host}") String host, @Value("${spring.data.redis.port}") int port) {
+        this.host = host;
+        this.port = port;
+    }
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public StringRedisTemplate stringRedisTemplate() {
+        StringRedisTemplate stringRedisTemplate = new StringRedisTemplate();
+        stringRedisTemplate.setConnectionFactory(redisConnectionFactory());
+        return stringRedisTemplate;
+    }
+}

--- a/src/main/java/com/growup/pms/common/exception/code/ErrorCode.java
+++ b/src/main/java/com/growup/pms/common/exception/code/ErrorCode.java
@@ -12,6 +12,7 @@ public enum ErrorCode {
 
     AUTH_AUTHENTICATION_ERROR(ErrorCategory.AUTHENTICATION_ERROR, "001", "인증을 실패했습니다."),
     INVALID_REFRESH_TOKEN_ERROR(ErrorCategory.AUTHENTICATION_ERROR, "002", "리프레시 토큰이 유효하지 않습니다."),
+    EMAIL_SENDING_ERROR(ErrorCategory.AUTHENTICATION_ERROR, "003", "이메일 전송에 실패했습니다."),
 
     AUTHZ_ACCESS_DENIED(ErrorCategory.AUTHORIZATION_ERROR, "001", "접근 권한이 없습니다."),
 

--- a/src/main/java/com/growup/pms/common/exception/exceptions/MessageFailureException.java
+++ b/src/main/java/com/growup/pms/common/exception/exceptions/MessageFailureException.java
@@ -1,0 +1,10 @@
+package com.growup.pms.common.exception.exceptions;
+
+import com.growup.pms.common.exception.code.ErrorCode;
+
+public class MessageFailureException extends BusinessException {
+
+    public MessageFailureException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/growup/pms/common/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/growup/pms/common/exception/handler/GlobalExceptionHandler.java
@@ -7,6 +7,7 @@ import com.growup.pms.common.exception.exceptions.AuthorizationException;
 import com.growup.pms.common.exception.exceptions.BusinessException;
 import com.growup.pms.common.exception.exceptions.DuplicateException;
 import com.growup.pms.common.exception.exceptions.EntityNotFoundException;
+import com.growup.pms.common.exception.exceptions.MessageFailureException;
 import com.growup.pms.common.exception.exceptions.StorageException;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
@@ -29,7 +30,7 @@ public class GlobalExceptionHandler {
                 .body(ErrorResponse.of(ex.getErrorCode()));
     }
 
-    @ExceptionHandler(DuplicateException.class)
+    @ExceptionHandler({DuplicateException.class, MessageFailureException.class})
     protected ResponseEntity<ErrorResponse> handleBadRequestException(BusinessException ex, HttpServletRequest request) {
         logInfo(ex, request);
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)

--- a/src/main/resources/application-common.yml
+++ b/src/main/resources/application-common.yml
@@ -1,8 +1,19 @@
 spring:
+  mail:
+    host: live.smtp.mailtrap.io
+    port: 587
+    username: api
+    password: ENC(nc+/bpDH70Gm6hmsOWniHJn/q39VOPb2khMnMid5jMNK8kQXhJJXKnyyEhV6nXzCRjxdXEYjzSo/CA7Q1b7NBCBlmvI30yb1G+bkKNYTiWA=)
+    properties:
+      mail.smtp.auth: true
+      mail.smtp.starttls.enable: true
+
   application:
     name: grow-up-pms
+
   jpa:
     open-in-view: false
+
   servlet:
     multipart:
       max-file-size: 10MB
@@ -25,3 +36,6 @@ security:
 springdoc:
   swagger-ui:
     url: /docs/openapi3.yaml
+
+mailtrap:
+  from: mailtrap@demomailtrap.com

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -23,3 +23,8 @@ spring:
     init:
       mode: always
       platform: local
+
+  data:
+    redis:
+      host: localhost
+      port: 6379

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -9,3 +9,8 @@ spring:
     hibernate:
       # FIXME: 추후에 서비스 개발이 끝나고 배포 환경이 구성되면 validate 혹은 none으로 변경해야 함
       ddl-auto: create
+
+  data:
+    redis:
+      host: redis
+      port: 6379

--- a/src/test/java/com/growup/pms/auth/service/EmailVerificationServiceTest.java
+++ b/src/test/java/com/growup/pms/auth/service/EmailVerificationServiceTest.java
@@ -1,0 +1,107 @@
+package com.growup.pms.auth.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+
+import com.growup.pms.auth.service.dto.EmailDetails;
+import com.growup.pms.auth.service.mail.MailClient;
+import com.growup.pms.test.annotation.AutoKoreanDisplayName;
+import java.time.Duration;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+@AutoKoreanDisplayName
+@SuppressWarnings("NonAsciiCharacters")
+@ExtendWith(MockitoExtension.class)
+class EmailVerificationServiceTest {
+    @Mock
+    MailClient mailClient;
+
+    @Mock
+    StringRedisTemplate stringRedisTemplate;
+
+    @Mock
+    ValueOperations<String, String> valueOperations;
+
+    @InjectMocks
+    EmailVerificationService emailVerificationService;
+
+    @Nested
+    class 이메일을_인증할_때 {
+        @Test
+        void 성공한다() {
+            // given
+            String email = "exists@email.com";
+            String code = "123456";
+
+            when(stringRedisTemplate.opsForValue()).thenReturn(valueOperations);
+            when(valueOperations.get(anyString())).thenReturn(code);
+
+            // when
+            boolean isVerified = emailVerificationService.verifyEmail(email, code);
+
+            // then
+            assertThat(isVerified).isTrue();
+        }
+
+        @Test
+        void 저장된_인증_코드가_없으면_인증에_실패한다() {
+            // given
+            String 이메일 = "not_exists@email.com";
+            String 코드 = "123456";
+
+            when(stringRedisTemplate.opsForValue()).thenReturn(valueOperations);
+            when(valueOperations.get(anyString())).thenReturn(null);
+
+            // when
+            boolean 인증_결과 = emailVerificationService.verifyEmail(이메일, 코드);
+
+            // then
+            assertThat(인증_결과).isFalse();
+        }
+
+        @Test
+        void 인증_코드가_일치하지_않으면_인증에_실패한다() {
+            // given
+            String 메일 = "not_exists@email.com";
+            String 코드 = "123456";
+            String 실제_코드 = "654321";
+
+            when(stringRedisTemplate.opsForValue()).thenReturn(valueOperations);
+            when(valueOperations.get(anyString())).thenReturn(실제_코드);
+
+            // when
+            boolean 인증_결과 = emailVerificationService.verifyEmail(메일, 코드);
+
+            // then
+            assertThat(인증_결과).isFalse();
+        }
+    }
+
+    @Nested
+    class 인증_이메일을_보낼_때 {
+        @Test
+        void 성공한다() {
+            // given
+            String 메일 = "exists@email.com";
+
+            when(stringRedisTemplate.opsForValue()).thenReturn(valueOperations);
+            doNothing().when(valueOperations).set(anyString(), anyString(), any(Duration.class));
+            doNothing().when(mailClient).sendEmail(any(EmailDetails.class));
+
+            // when
+            assertThatCode(() -> emailVerificationService.getAndSetVerificationCode(메일))
+                    .doesNotThrowAnyException();
+        }
+    }
+}

--- a/src/test/java/com/growup/pms/auth/service/RefreshTokenServiceTest.java
+++ b/src/test/java/com/growup/pms/auth/service/RefreshTokenServiceTest.java
@@ -18,7 +18,8 @@ import com.growup.pms.common.security.jwt.JwtTokenProvider;
 import com.growup.pms.test.annotation.AutoKoreanDisplayName;
 import com.growup.pms.user.domain.User;
 import com.growup.pms.user.repository.UserRepository;
-import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.Optional;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -88,7 +89,7 @@ class RefreshTokenServiceTest {
 
             when(refreshTokenRepository.findByUserId(기존_사용자_ID)).thenReturn(Optional.of(기존_리프레시_토큰));
             when(기존_리프레시_토큰.getId()).thenReturn(기존_리프레시_토큰_ID);
-            doNothing().when(기존_리프레시_토큰).updateToken(eq(새_리프레시_토큰), any(Instant.class));
+            doNothing().when(기존_리프레시_토큰).renewToken(eq(새_리프레시_토큰), any(LocalDateTime.class));
 
             // when
             Long 새_리프레시_토큰_ID = refreshTokenService.renewRefreshToken(기존_사용자_ID, 새_리프레시_토큰);
@@ -123,7 +124,7 @@ class RefreshTokenServiceTest {
             // given
             Long 기존_사용자_ID = 1L;
             User 기존_사용자 = 사용자는().식별자가(기존_사용자_ID).이다();
-            Instant 유효한_만료기한 = Instant.now().plusMillis(1000);
+            LocalDateTime 유효한_만료기한 = LocalDateTime.now().plus(1000, ChronoUnit.MILLIS);
             RefreshToken 유효한_토큰 = 리프레시_토큰은().사용자가(기존_사용자).만료기한이(유효한_만료기한).이다();
 
             when(tokenProvider.validateToken(유효한_토큰.getToken())).thenReturn(true);
@@ -176,7 +177,7 @@ class RefreshTokenServiceTest {
             // given
             Long 기존_사용자_ID = 1L;
             User 기존_사용자 = 사용자는().식별자가(기존_사용자_ID).이다();
-            Instant 만료된_만료기한 = Instant.now().minusMillis(1000);
+            LocalDateTime 만료된_만료기한 = LocalDateTime.now().minus(1000, ChronoUnit.MILLIS);
             RefreshToken 만료된_토큰 = 리프레시_토큰은().사용자가(기존_사용자).만료기한이(만료된_만료기한).이다();
 
             when(tokenProvider.validateToken(만료된_토큰.getToken())).thenReturn(true);

--- a/src/test/java/com/growup/pms/auth/service/mail/MailtrapClientTest.java
+++ b/src/test/java/com/growup/pms/auth/service/mail/MailtrapClientTest.java
@@ -1,0 +1,71 @@
+package com.growup.pms.auth.service.mail;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.growup.pms.auth.service.dto.EmailDetails;
+import com.growup.pms.test.annotation.AutoKoreanDisplayName;
+import jakarta.mail.internet.MimeMessage;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@AutoKoreanDisplayName
+@SuppressWarnings("NonAsciiCharacters")
+@ExtendWith(MockitoExtension.class)
+class MailtrapClientTest {
+    @Mock
+    JavaMailSender javaMailSender;
+
+    @InjectMocks
+    MailtrapClient mailtrapClient;
+
+    static final String 보내는_사람_이메일 = "sandbox@mailtrap.io";
+
+    @Test
+    void 이메일을_보내는_데_성공한다() {
+        // given
+        EmailDetails 메일 = EmailDetails.builder()
+                .subject("제목")
+                .content("내용")
+                .recipient("recipient@example.org")
+                .build();
+        MimeMessage 메시지 = mock(MimeMessage.class);
+
+        when(javaMailSender.createMimeMessage()).thenReturn(메시지);
+        doNothing().when(javaMailSender).send(메시지);
+
+        ReflectionTestUtils.setField(mailtrapClient, "sandboxSenderEmail", 보내는_사람_이메일);
+
+        // when & then
+        assertThatCode(() -> mailtrapClient.sendEmail(메일))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void 수신자가_없으면_예외가_발생한다() {
+        // given
+        EmailDetails 메일 = EmailDetails.builder()
+                .subject("제목")
+                .content("내용")
+                .recipient(null)
+                .build();
+        MimeMessage 메시지 = mock(MimeMessage.class);
+
+        when(javaMailSender.createMimeMessage()).thenReturn(메시지);
+
+        ReflectionTestUtils.setField(mailtrapClient, "sandboxSenderEmail", 보내는_사람_이메일);
+
+        // when & then
+        assertThatThrownBy(() -> mailtrapClient.sendEmail(메일))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("To address must not be null");
+    }
+}

--- a/src/test/java/com/growup/pms/test/fixture/auth/RefreshTokenTestBuilder.java
+++ b/src/test/java/com/growup/pms/test/fixture/auth/RefreshTokenTestBuilder.java
@@ -3,7 +3,8 @@ package com.growup.pms.test.fixture.auth;
 import com.growup.pms.auth.domain.RefreshToken;
 import com.growup.pms.test.fixture.user.UserTestBuilder;
 import com.growup.pms.user.domain.User;
-import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
@@ -16,7 +17,7 @@ public class RefreshTokenTestBuilder {
     private Long id = 1L;
     private User user = UserTestBuilder.사용자는().이다();
     private String token = "유효한 리프레시 토큰";
-    private Instant expiryDate = Instant.now().plusMillis(1000);
+    private LocalDateTime expiredAt = LocalDateTime.now().plus(1000, ChronoUnit.MILLIS);
 
     public static RefreshTokenTestBuilder 리프레시_토큰은() {
         return new RefreshTokenTestBuilder();
@@ -32,8 +33,8 @@ public class RefreshTokenTestBuilder {
         return this;
     }
 
-    public RefreshTokenTestBuilder 만료기한이(Instant 만료기한) {
-        this.expiryDate = 만료기한;
+    public RefreshTokenTestBuilder 만료기한이(LocalDateTime 만료기한) {
+        this.expiredAt = 만료기한;
         return this;
     }
 
@@ -41,7 +42,7 @@ public class RefreshTokenTestBuilder {
         var refreshToken = RefreshToken.builder()
                 .user(user)
                 .token(token)
-                .expiryDate(expiryDate)
+                .expiryDate(expiredAt)
                 .build();
         ReflectionTestUtils.setField(refreshToken, "id", id);
         return refreshToken;

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -11,3 +11,21 @@ security:
 
 storage:
   root-path: src/test/resources/
+
+spring:
+  mail:
+    host: live.smtp.mailtrap.io
+    port: 587
+    username: api
+    password: ENC(nc+/bpDH70Gm6hmsOWniHJn/q39VOPb2khMnMid5jMNK8kQXhJJXKnyyEhV6nXzCRjxdXEYjzSo/CA7Q1b7NBCBlmvI30yb1G+bkKNYTiWA=)
+    properties:
+      mail.smtp.auth: true
+      mail.smtp.starttls.enable: true
+
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
+mailtrap:
+  from: mailtrap@demomailtrap.com


### PR DESCRIPTION
## PR Type

- [x] **\[Feat\]** 🎨 새로운 기능을 추가했어요.
- [x] **\[Config\]** ⚙ 환경설정을 변경했어요.
- [x] **\[Test\]** 🧪 테스트 코드를 추가/삭제/변경 했어요.
- [x] **\[Chore\]** 🛒 빌드 프로세스 변경, 의존성 패키지 업데이트 했어요.

## Related Issues

- close #167 

## What does this PR do?

- [x] 레디스와 메일에 대한 의존성을 추가함
- [x] 이메일 인증 코드를 전송하는 기능을 구현함
- [x] 인증 코드를 검증하는 기능을 구현함
- [x] 테스트 코드 작성
  - [x] 유닛 테스트
  - [x] 문서 테스트

## Other Information
### 스프링 부트를 통해 메일 전송
특이한 이유가 없다면 간단한 방법은 당연히 자체 서버를 구축하는 것이 아니라 외부 서버를 사용하는 것입니다. 외부 서버를 사용하는 경우에 특히 지메일을 많이 사용하게 되는데, 보안 문제상 기존 메일을 쓸 수는 없었고 프로젝트를 할 때마다 테스트 계정을 매번 만들 수는 없었습니다.

## Mailtrap
`Mailtrap`은 개발자를 위한 이메일 테스트 서비스라고 할 수 있습니다. 이 서비스를 통해서 개발자가 실제 이메일을 보내지 않고도 애플리케이션의 이메일 기능을 테스트할 수 있습니다. 자동화된 테스트를 위한 API를 제공하고, 다양한 프레임워크를 지원하고 있는데 스프링 부트를 포함한 여러 프레임워크와의 통합도 용이하다고 하네요.

가입도 메일이랑 비밀번호만 입력하면 끝나는 수준이라 간편한 편입니다.

### 가격 
무료 기준으로 일당 200건의 메일을 전송할 수 있고 개월당 1000건의 메일을 보낼 수 있는데 이건 테스트를 마치고도 충분히 남는 수라고 할 수 있습니다.

<p align="center"><img width="500px" src="https://github.com/user-attachments/assets/d69ea7e8-3408-4fe2-a85c-eec479a7ee4e" /></p>

### 빠른 시작
#### 설정
```yaml
spring:
  mail:
    host: live.smtp.mailtrap.io
    port: 587
    username: api
    password: # Mailtrap 비밀번호 #
    properties:
      mail.smtp.auth: true
      mail.smtp.starttls.enable: true
```

#### 레디스 설정
이메일 인증 번호는 지정된 시간(예: 60초)이 지나면 사라져야 하는 정보인데, 이걸 영속성 저장소에서 다루기에는 좋지 않습니다. 차라리 접근 속도가 상대적으로 빠른 휘발성 메모리에 데이터를 올리고 지정된 시간이 지나면 만료시키는 것이 좋다고 생각되었습니다.

직접 스케줄링을 통해서 구현할 수도 있겠지만, 잘 알려진 인메모리 저장소인 레디스를 사용하면 TTL(Time To Live) 값을 설정할 수 있어서 편하게 저장하고 만료시킬 수 있습니다.