### PR TITLE
Test: #192 멱등성을 위해 테스트에 Testcontainers를 통해 프로덕션 환경과 일치시킴

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-mail'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.boot:spring-boot-testcontainers'
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
     // Lombok

--- a/src/main/java/com/growup/pms/common/BaseEntity.java
+++ b/src/main/java/com/growup/pms/common/BaseEntity.java
@@ -19,7 +19,7 @@ public abstract class BaseEntity {
     private LocalDateTime createdAt;
 
     @LastModifiedDate
-    private LocalDateTime modifiedAt;
+    private LocalDateTime updatedAt;
 
     @Column(nullable = false)
     @ColumnDefault("false")

--- a/src/main/java/com/growup/pms/role/domain/Permission.java
+++ b/src/main/java/com/growup/pms/role/domain/Permission.java
@@ -1,6 +1,5 @@
 package com.growup.pms.role.domain;
 
-import com.growup.pms.common.BaseEntity;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -15,16 +14,12 @@ import java.util.List;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.SQLDelete;
-import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Getter
 @Table(name = "permissions")
-@SQLDelete(sql = "UPDATE permissions SET is_deleted = true WHERE id = ?")
-@SQLRestriction("is_deleted = false")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Permission extends BaseEntity {
+public class Permission {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/com/growup/pms/role/domain/Role.java
+++ b/src/main/java/com/growup/pms/role/domain/Role.java
@@ -1,6 +1,5 @@
 package com.growup.pms.role.domain;
 
-import com.growup.pms.common.BaseEntity;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -17,16 +16,12 @@ import java.util.List;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.SQLDelete;
-import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Getter
 @Table(name = "roles", uniqueConstraints = @UniqueConstraint(columnNames = {"type", "name"}))
-@SQLDelete(sql = "UPDATE roles SET is_deleted = true WHERE id = ?")
-@SQLRestriction("is_deleted = false")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Role extends BaseEntity {
+public class Role {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/com/growup/pms/role/domain/RolePermission.java
+++ b/src/main/java/com/growup/pms/role/domain/RolePermission.java
@@ -1,6 +1,5 @@
 package com.growup.pms.role.domain;
 
-import com.growup.pms.common.BaseEntity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.ForeignKey;
 import jakarta.persistence.Id;
@@ -11,17 +10,13 @@ import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.SQLDelete;
-import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Getter
 @IdClass(RolePermissionId.class)
 @Table(name = "role_permissions")
-@SQLDelete(sql = "UPDATE role_permissions SET is_deleted = true WHERE role_id = ? AND permission_id = ?")
-@SQLRestriction("is_deleted = false")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class RolePermission extends BaseEntity {
+public class RolePermission {
     @Id
     @ManyToOne
     @JoinColumn(name = "role_id", foreignKey = @ForeignKey(name = "fk_role_permission_role"))

--- a/src/test/java/com/growup/pms/common/storage/service/FileSystemStorageServiceTest.java
+++ b/src/test/java/com/growup/pms/common/storage/service/FileSystemStorageServiceTest.java
@@ -1,5 +1,6 @@
 package com.growup.pms.common.storage.service;
 
+import com.growup.pms.test.annotation.ContainerTest;
 import java.io.File;
 import java.io.FileInputStream;
 import java.nio.file.Files;
@@ -15,6 +16,7 @@ import org.springframework.core.io.Resource;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 
+@ContainerTest
 @SpringBootTest
 class FileSystemStorageServiceTest {
 

--- a/src/test/java/com/growup/pms/status/repository/StatusQueryRepositoryImplTest.java
+++ b/src/test/java/com/growup/pms/status/repository/StatusQueryRepositoryImplTest.java
@@ -121,7 +121,6 @@ class StatusQueryRepositoryImplTest extends RepositoryTestSupport {
 
             // then
             assertThat(실제_결과).hasSize(3);
-            System.out.println(실제_결과);
             assertThat(실제_결과.stream().map(StatusResponse::name))
                     .containsExactlyInAnyOrder("할일", "진행중", "완료");
         }

--- a/src/test/java/com/growup/pms/team/repository/QueryDslTeamUserRepositoryImplTest.java
+++ b/src/test/java/com/growup/pms/team/repository/QueryDslTeamUserRepositoryImplTest.java
@@ -61,7 +61,6 @@ class QueryDslTeamUserRepositoryImplTest extends RepositoryTestSupport {
 
     @BeforeEach
     void setUp() {
-        System.out.println("QueryDslTeamUserRepositoryImplTest.setUp");
         어드민 = roleRepository.save(역할은().식별자가(1L).타입이(TEAM).이름이(HEAD.getRoleName()).이다());
         리더 = roleRepository.save(역할은().식별자가(2L).타입이(TEAM).이름이(LEADER.getRoleName()).이다());
         메이트 = roleRepository.save(역할은().식별자가(3L).타입이(TEAM).이름이(MATE.getRoleName()).이다());

--- a/src/test/java/com/growup/pms/test/annotation/ContainerTest.java
+++ b/src/test/java/com/growup/pms/test/annotation/ContainerTest.java
@@ -1,0 +1,14 @@
+package com.growup.pms.test.annotation;
+
+import com.growup.pms.test.support.TestcontainersInitializer;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.test.context.ContextConfiguration;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@ContextConfiguration(initializers = TestcontainersInitializer.class)
+public @interface ContainerTest {
+}

--- a/src/test/java/com/growup/pms/test/support/RepositoryTestSupport.java
+++ b/src/test/java/com/growup/pms/test/support/RepositoryTestSupport.java
@@ -3,11 +3,13 @@ package com.growup.pms.test.support;
 import static org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
 
 import com.growup.pms.common.config.QueryDslConfig;
+import com.growup.pms.test.annotation.ContainerTest;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 
 @DataJpaTest
+@ContainerTest
 @Import({QueryDslConfig.class})
 @AutoConfigureTestDatabase(replace = Replace.NONE)
 public abstract class RepositoryTestSupport {

--- a/src/test/java/com/growup/pms/test/support/TestcontainersInitializer.java
+++ b/src/test/java/com/growup/pms/test/support/TestcontainersInitializer.java
@@ -1,0 +1,25 @@
+package com.growup.pms.test.support;
+
+import org.springframework.boot.test.util.TestPropertyValues;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.testcontainers.containers.MariaDBContainer;
+import org.testcontainers.lifecycle.Startables;
+
+public class TestcontainersInitializer implements ApplicationContextInitializer<ConfigurableApplicationContext> {
+    static MariaDBContainer<?> mariadb = new MariaDBContainer<>("mariadb:11.5.2")
+            .withReuse(true);
+
+    static {
+        Startables.deepStart(mariadb).join();
+    }
+
+    @Override
+    public void initialize(ConfigurableApplicationContext applicationContext) {
+        TestPropertyValues.of(
+                "spring.datasource.url=" + mariadb.getJdbcUrl(),
+                "spring.datasource.username=" + mariadb.getUsername(),
+                "spring.datasource.password=" + mariadb.getPassword()
+        ).applyTo(applicationContext.getEnvironment());
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,17 +1,3 @@
-jasypt:
-  encryptor:
-    bean: jasyptEncryptorAES
-    password: ${JASYPT_PASSWORD}
-
-security:
-  jwt:
-    base64-secret: ENC(IAOzDB87WA/evdFrSSzDsmgtpFC+fIev+ckx+Qb3+KFwLpCPInk8oPxILwE33IdUchcesVhpzuO1PjKaIqFAOZINbJniiuuzr/PZ0FSDhYM=)
-    access-token-expiration-millis: 86400000
-    refresh-token-expiration-millis: 604800000
-
-storage:
-  root-path: src/test/resources/
-
 spring:
   mail:
     host: live.smtp.mailtrap.io
@@ -22,10 +8,32 @@ spring:
       mail.smtp.auth: true
       mail.smtp.starttls.enable: true
 
+  jpa:
+    hibernate:
+      ddl-auto: none
+
+  sql:
+    init:
+      mode: always
+
   data:
     redis:
       host: localhost
       port: 6379
+
+storage:
+  root-path: src/test/resources/
+
+jasypt:
+  encryptor:
+    bean: jasyptEncryptorAES
+    password: ${JASYPT_PASSWORD}
+
+security:
+  jwt:
+    base64-secret: ENC(IAOzDB87WA/evdFrSSzDsmgtpFC+fIev+ckx+Qb3+KFwLpCPInk8oPxILwE33IdUchcesVhpzuO1PjKaIqFAOZINbJniiuuzr/PZ0FSDhYM=)
+    access-token-expiration-millis: 86400000
+    refresh-token-expiration-millis: 604800000
 
 mailtrap:
   from: mailtrap@demomailtrap.com

--- a/src/test/resources/schema.sql
+++ b/src/test/resources/schema.sql
@@ -88,7 +88,7 @@ CREATE TABLE IF NOT EXISTS projects (
     CONSTRAINT fk_project_team FOREIGN KEY (team_id) REFERENCES teams(id)
 );
 
-CREATE TABLE project_status (
+CREATE TABLE IF NOT EXISTS project_status (
     id          BIGINT          AUTO_INCREMENT PRIMARY KEY,
     project_id  BIGINT          NOT NULL,
     name        VARCHAR(32)     NOT NULL,
@@ -101,7 +101,7 @@ CREATE TABLE project_status (
 );
 
 -- 프로젝트 일정
-CREATE TABLE status_tasks (
+CREATE TABLE IF NOT EXISTS status_tasks (
     id                  BIGINT          AUTO_INCREMENT PRIMARY KEY,
     project_status_id   BIGINT          NOT NULL,
     user_id             BIGINT,

--- a/src/test/resources/schema.sql
+++ b/src/test/resources/schema.sql
@@ -1,0 +1,118 @@
+-- 역할/권한
+CREATE TABLE IF NOT EXISTS roles (
+    id          BIGINT                  AUTO_INCREMENT PRIMARY KEY,
+    type        ENUM('TEAM', 'PROJECT') NOT NULL,
+    name        VARCHAR(20)             NOT NULL,
+    UNIQUE KEY  uk_roles_type_name (type, name)
+);
+
+CREATE TABLE IF NOT EXISTS permissions (
+    id      BIGINT          AUTO_INCREMENT PRIMARY KEY,
+    name    VARCHAR(255)    NOT NULL UNIQUE
+);
+
+CREATE TABLE IF NOT EXISTS role_permissions (
+    role_id         BIGINT  NOT NULL,
+    permission_id   BIGINT  NOT NULL,
+    CONSTRAINT  fk_role_permission_role       FOREIGN KEY (role_id)       REFERENCES roles (id),
+    CONSTRAINT  fk_role_permission_permission FOREIGN KEY (permission_id) REFERENCES permissions (id),
+    PRIMARY KEY (role_id, permission_id)
+);
+
+-- 사용자
+CREATE TABLE IF NOT EXISTS users (
+    id                      BIGINT                              AUTO_INCREMENT PRIMARY KEY,
+    username                VARCHAR(32)                         NOT NULL UNIQUE,
+    password                VARCHAR(128),
+    email                   VARCHAR(128)                        NOT NULL,
+    provider                ENUM('LOCAL', 'KAKAO', 'GOOGLE')    NOT NULL,
+    nickname                VARCHAR(20)                         NOT NULL,
+    bio                     TEXT,
+    image                   VARCHAR(255),
+    image_name              VARCHAR(255),
+    password_change_date    DATETIME                            NOT NULL,
+    password_failure_count  INT                                 NOT NULL DEFAULT 0,
+    created_at              DATETIME,
+    updated_at              DATETIME,
+    is_deleted              BOOLEAN                             NOT NULL DEFAULT FALSE
+);
+
+CREATE TABLE IF NOT EXISTS user_links (
+    id          BIGINT      AUTO_INCREMENT PRIMARY KEY,
+    user_id     BIGINT      NOT NULL,
+    link                    VARCHAR(255) NOT NULL,
+    created_at  DATETIME,
+    updated_at  DATETIME,
+    is_deleted  BOOLEAN     NOT NULL DEFAULT FALSE,
+    CONSTRAINT fk_user_link FOREIGN KEY (user_id) REFERENCES users(id)
+);
+
+-- 팀
+CREATE TABLE IF NOT EXISTS teams (
+    id          BIGINT AUTO_INCREMENT   PRIMARY KEY,
+    creator_id  BIGINT                  NOT NULL,
+    name        VARCHAR(10)             NOT NULL,
+    content     VARCHAR(200),
+    created_at  DATETIME,
+    updated_at  DATETIME,
+    is_deleted  BOOLEAN                 NOT NULL DEFAULT FALSE,
+    CONSTRAINT  fk_team_creator FOREIGN KEY (creator_id) REFERENCES users(id),
+    UNIQUE KEY  uk_team_creator_name (creator_id, name)
+);
+
+CREATE TABLE IF NOT EXISTS team_users (
+    team_id             BIGINT      NOT NULL,
+    user_id             BIGINT      NOT NULL,
+    role_id             BIGINT      NOT NULL,
+    is_pending_approval BOOLEAN     NOT NULL,
+    is_deleted          BOOLEAN     NOT NULL DEFAULT FALSE,
+    created_at          DATETIME,
+    updated_at          DATETIME,
+    PRIMARY KEY (team_id, user_id),
+    CONSTRAINT fk_team_user_team FOREIGN KEY (team_id) REFERENCES teams (id),
+    CONSTRAINT fk_team_user_user FOREIGN KEY (user_id) REFERENCES users (id),
+    CONSTRAINT fk_team_user_role FOREIGN KEY (role_id) REFERENCES roles (id)
+);
+
+-- 프로젝트
+CREATE TABLE IF NOT EXISTS projects (
+    id          BIGINT          AUTO_INCREMENT PRIMARY KEY,
+    team_id     BIGINT          NOT NULL,
+    name        VARCHAR(128)    NOT NULL,
+    content     VARCHAR(200),
+    start_date  DATE,
+    end_date    DATE,
+    created_at  DATETIME,
+    updated_at  DATETIME,
+    is_deleted  BOOLEAN         NOT NULL DEFAULT FALSE,
+    CONSTRAINT fk_project_team FOREIGN KEY (team_id) REFERENCES teams(id)
+);
+
+CREATE TABLE project_status (
+    id          BIGINT          AUTO_INCREMENT PRIMARY KEY,
+    project_id  BIGINT          NOT NULL,
+    name        VARCHAR(32)     NOT NULL,
+    color_code  CHAR(6)         NOT NULL,
+    sort_order  SMALLINT        NOT NULL,
+    is_deleted  BOOLEAN         NOT NULL DEFAULT FALSE,
+    created_at  DATETIME,
+    updated_at  DATETIME,
+    CONSTRAINT fk_status_project FOREIGN KEY (project_id) REFERENCES projects (id)
+);
+
+-- 프로젝트 일정
+CREATE TABLE status_tasks (
+    id                  BIGINT          AUTO_INCREMENT PRIMARY KEY,
+    project_status_id   BIGINT          NOT NULL,
+    user_id             BIGINT,
+    name                VARCHAR(128)    NOT NULL,
+    content             LONGTEXT,
+    sort_order          SMALLINT        NOT NULL,
+    start_date          DATE,
+    end_date            DATE,
+    is_deleted          BOOLEAN         NOT NULL DEFAULT FALSE,
+    created_at          DATETIME,
+    updated_at          DATETIME,
+    CONSTRAINT fk_task_status FOREIGN KEY (project_status_id)  REFERENCES project_status (id),
+    CONSTRAINT fk_task_user   FOREIGN KEY (user_id)            REFERENCES users (id)
+);


### PR DESCRIPTION
## PR Type

- [x] **\[Fix\]** 🐞 버그를 수정했어요.
- [x] **\[Refactor\]** 🛠 리팩토링을 했어요 (기능적인 변화 없이, api 변경 없이)
- [x] **\[Test\]** 🧪 테스트 코드를 추가/삭제/변경 했어요.

## Related Issues

- close #192 

## What does this PR do?

<!--무엇을 하셨나요?-->

- [x] 멱등성을 위해 테스트에 Testcontainers를 통해 프로덕션 환경과 일치시킴
- [x] 권한/역할 테이블에서 불필요한 감사 테이블 제거함

## Other information
### ApplicationContextInitializer
스프링 애플리케이션 컨텍스트가 완전히 초기화되기 전에 추가적인 프로그래밍 방식의 초기화 작업을 수행할 수 있습니다. 이 인터페이스는 주로 애플리케이션의 초기 설정이나 환경 구성을 커스터마이즈하는 데 사용되는 것 같습니다.

### @ContextConfiguration
이 애노테이션은 통합 테스트를 위한 `ApplicationContext`를 로드하고 구성하는 데 사용되고 있습니다. 컨텍스트가 뜰 때 ApplicationContextInitializer의 구현체인 TestcontainersInitializer를 initializer로 받아서 컨테이너와 관련된 설정을 하고 병렬적으로 컨테이너를 실행하는 역할을 하고 있습니다.

### 병렬 컨테이너를 시작하는 방법
두 개 이상의 컨테이너가 실행되어야 할 때 순차적으로 실행되는데, `Startables.deepStart(container1, container2m, ...).join()`과 같이 작성하면 모든 컨테이너를 병렬로 시작한다고 합니다. 이를 통해 컨테이너를 시작할 때 드는 오버헤드로 인한 영향을 줄일 수 있습니다.

```java
static {
    Startables.deepStart(mariadb).join();
}
```

### 재사용 가능한 컨테이너
현재는 모든 테스트 메서드가 실행되기 전에 도커 컨테이너가 올라올 때까지 대기하는 시간이 있어서 다소 느리게 느껴질 수 있습니다. 여기서 어떻게 개선시킬 수 있을까 생각했습니다.

이 기능은 실험적 기능이고, 이 컨테이너는 모든 테스트가 완료된 후에도 내려가지 않는다고 합니다. 즉, 컨테이너를 계속 실행 상태로 유지하고 동일한 컨테이너 설정으로 다음 테스트 실행 시에 이를 재사용하고 있는 것 같습니다.

활성화 하는 방법은 `TESTCONTAINERS_REUSE_ENABLE=true` 환경 변수를 추가하거나 `~/.testcontainers.properties`에 `testcontainers.reuse.enable=true`를 추가하면 됩니다. 그리고 아래와 같이 `withReuse()` 메서드를 통해 컨테이너를 재사용하도록 지정해야 합니다.

```java
// 라이프 사이클을 수동으로 관리하기 위해 @Container는 제거한다.
private final static MariaDBContainer<?> mariaDb = new MariaDBContainer<>("mariadb:latest")
		.withReuse(true);

// 수동으로 start() 메서드를 호출하여 컨테이너를 시작한다.
@BeforeAll
static void startDbContainer() {
	mariaDb.start();
}
```

실행하면 아래와 같이 컨테이너를 재사용하고 있다는 로그를 볼 수 있습니다.

```log
20:10:59.750 [Test worker] INFO tc.mariadb:latest -- Creating container for image: mariadb:latest
20:10:59.840 [Test worker] INFO tc.mariadb:latest -- Reusing container with ID: 136db9788a8c6e874c8644684b8816111e76de4762fe78bfe83e7b3b8e72e3ab and hash: 0c5ffcbded83b4a30c9b9a2d6bc99f7475703602
20:10:59.841 [Test worker] INFO tc.mariadb:latest -- Reusing existing container (136db9788a8c6e874c8644684b8816111e76de4762fe78bfe83e7b3b8e72e3ab) and not creating a new one
```

테스트가 모두 끝난 후에 실행 중인 컨테이너를 확인해보면 종료되지 않고 계속 올라와 있는 것을 볼 수 있습니다. 참고해야 할 점은, 이 컨테이너는 **개발자가 수동으로 중지시켜야 한다는 점**인데 이 부분은 주의하면 좋을 것 같습니다.

## Reference
- [Advanced options - Testcontainers for Java](https://java.testcontainers.org/features/advanced_options/)