### PR TITLE
Feat: #226 팀 목록 조회 API의 응답에 팀장 ID를 같이 내리도록 수정함

### DIFF
--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -47,7 +47,7 @@ jobs:
           report_paths: '**/build/test-results/test/TEST-*.xml'
 
       - name: Archive coverage data
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: java-coverage-data
           path: .qodana/code-coverage

--- a/src/main/java/com/growup/pms/user/controller/dto/response/UserTeamResponse.java
+++ b/src/main/java/com/growup/pms/user/controller/dto/response/UserTeamResponse.java
@@ -8,6 +8,7 @@ public record UserTeamResponse(
         String teamName,
         String content,
         String creator,
+        Long creatorId,
         boolean isPendingApproval,
         String roleName
 ) {

--- a/src/main/java/com/growup/pms/user/repository/QueryDslUserRepositoryImpl.java
+++ b/src/main/java/com/growup/pms/user/repository/QueryDslUserRepositoryImpl.java
@@ -40,6 +40,7 @@ public class QueryDslUserRepositoryImpl implements QueryDslUserRepository {
                         team.name,
                         team.content,
                         user.profile.nickname,
+                        user.id,
                         teamUser.isPendingApproval,
                         role.name
                 ))

--- a/src/main/resources/static/docs/openapi3.yaml
+++ b/src/main/resources/static/docs/openapi3.yaml
@@ -983,7 +983,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/api-v1-user-team-1051270522'
+                $ref: '#/components/schemas/api-v1-user-team-928817730'
               examples:
                 user-controller-v1-docs-test/가입한_팀_목록_조회_api_문서를_생성한다:
                   value: |-
@@ -992,6 +992,7 @@ paths:
                       "teamName" : "팀 이름",
                       "content" : "팀 소개",
                       "creator" : "팀장 닉네임",
+                      "creatorId" : 1,
                       "isPendingApproval" : true,
                       "roleName" : "MATE"
                     } ]
@@ -1831,29 +1832,6 @@ components:
         content:
           type: string
           description: 일정 내용
-    api-v1-user-team-1051270522:
-      type: array
-      items:
-        type: object
-        properties:
-          teamName:
-            type: string
-            description: 팀 이름
-          creator:
-            type: string
-            description: 팀장 닉네임
-          teamId:
-            type: number
-            description: 팀 ID
-          roleName:
-            type: string
-            description: 팀 내에서의 역할
-          isPendingApproval:
-            type: boolean
-            description: 가입 대기 여부
-          content:
-            type: string
-            description: 팀 소개
     api-v1-user-recover-username1645263616:
       type: object
       properties:
@@ -1914,6 +1892,32 @@ components:
         content:
           type: string
           description: 프로젝트 설명
+    api-v1-user-team-928817730:
+      type: array
+      items:
+        type: object
+        properties:
+          teamName:
+            type: string
+            description: 팀 이름
+          creator:
+            type: string
+            description: 팀장 닉네임
+          teamId:
+            type: number
+            description: 팀 ID
+          roleName:
+            type: string
+            description: 팀 내에서의 역할
+          creatorId:
+            type: number
+            description: 팀장 ID
+          isPendingApproval:
+            type: boolean
+            description: 가입 대기 여부
+          content:
+            type: string
+            description: 팀 소개
     api-v1-team-teamId-user-targetMemberId-role-1605929895:
       type: object
       properties:

--- a/src/test/java/com/growup/pms/docs/UserControllerV1DocsTest.java
+++ b/src/test/java/com/growup/pms/docs/UserControllerV1DocsTest.java
@@ -137,6 +137,7 @@ class UserControllerV1DocsTest extends ControllerSliceTestSupport {
                                         fieldWithPath("[].teamName").type(JsonFieldType.STRING).description("팀 이름"),
                                         fieldWithPath("[].content").type(JsonFieldType.STRING).description("팀 소개"),
                                         fieldWithPath("[].creator").type(JsonFieldType.STRING).description("팀장 닉네임"),
+                                        fieldWithPath("[].creatorId").type(JsonFieldType.NUMBER).description("팀장 ID"),
                                         fieldWithPath("[].isPendingApproval").type(JsonFieldType.BOOLEAN).description("가입 대기 여부"),
                                         fieldWithPath("[].roleName").type(JsonFieldType.STRING).description("팀 내에서의 역할"))
                                 .responseHeaders(headerWithName(HttpHeaders.CONTENT_TYPE).description(MediaType.APPLICATION_JSON_VALUE))

--- a/src/test/java/com/growup/pms/test/fixture/user/builder/UserTeamResponseTestBuilder.java
+++ b/src/test/java/com/growup/pms/test/fixture/user/builder/UserTeamResponseTestBuilder.java
@@ -13,6 +13,7 @@ public class UserTeamResponseTestBuilder {
     private String name = "팀 이름";
     private String content = "팀 소개";
     private String creator = "팀장 닉네임";
+    private Long creatorId = 1L;
     private boolean isPendingApproval = true;
     private String role = "MATE";
 
@@ -40,6 +41,11 @@ public class UserTeamResponseTestBuilder {
         return this;
     }
 
+    public UserTeamResponseTestBuilder 팀장_식별자가(Long 팀장_식별자) {
+        this.creatorId = 팀장_식별자;
+        return this;
+    }
+
     public UserTeamResponseTestBuilder 가입_대기_여부가(boolean 가입_대기_여부) {
         this.isPendingApproval = 가입_대기_여부;
         return this;
@@ -51,6 +57,6 @@ public class UserTeamResponseTestBuilder {
     }
 
     public UserTeamResponse 이다() {
-        return new UserTeamResponse(teamId, name, content, creator, isPendingApproval, role);
+        return new UserTeamResponse(teamId, name, content, creator, creatorId, isPendingApproval, role);
     }
 }

--- a/src/test/java/com/growup/pms/user/repository/QueryDslUserRepositoryImplTest.java
+++ b/src/test/java/com/growup/pms/user/repository/QueryDslUserRepositoryImplTest.java
@@ -136,12 +136,12 @@ class QueryDslUserRepositoryImplTest extends RepositoryTestSupport {
 
         UserTeamResponse 팀에_가입한_상태일_것으로_예상한다(Team 가입한_팀, String 팀_역할) {
             return new UserTeamResponse(가입한_팀.getId(), 가입한_팀.getName(), 가입한_팀.getContent(),
-                    가입한_팀.getCreator().getProfile().getNickname(), false, 팀_역할);
+                    가입한_팀.getCreator().getProfile().getNickname(), 가입한_팀.getCreator().getId(), false, 팀_역할);
         }
 
         UserTeamResponse 팀에_가입_대기_중인_상태일_것으로_예상한다(Team 가입한_팀, String 팀_역할) {
             return new UserTeamResponse(가입한_팀.getId(), 가입한_팀.getName(), 가입한_팀.getContent(),
-                    가입한_팀.getCreator().getProfile().getNickname(), true, 팀_역할);
+                    가입한_팀.getCreator().getProfile().getNickname(), 가입한_팀.getCreator().getId(), true, 팀_역할);
         }
     }
 }


### PR DESCRIPTION
## PR Type

- [x] **\[Feat\]** 🎨 새로운 기능을 추가했어요.

## Related Issues

- close #226 

## What does this PR do?

- [x] 팀 목록 조회 API의 응답에 팀장 ID를 같이 내리도록 수정함
- [x] 테스트 확인

## Other information

![image](https://github.com/user-attachments/assets/20f97871-43de-4a5b-b4c1-5b088e5e7b77)