### PR TITLE
Feat: #304 팀 생성 로직을 추가함

### DIFF
--- a/src/main/java/com/growup/pms/common/config/WebConfig.java
+++ b/src/main/java/com/growup/pms/common/config/WebConfig.java
@@ -7,6 +7,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
+// TODO: 프론트 서버가 배포되면 기본값으로 Lax를 사용하므로 나중에 이 설정 파일을 제거해야 함
 public class WebConfig {
 
     @Bean

--- a/src/main/java/com/growup/pms/common/exception/code/ErrorCode.java
+++ b/src/main/java/com/growup/pms/common/exception/code/ErrorCode.java
@@ -53,6 +53,7 @@ public enum ErrorCode {
     TEAM_NOT_FOUND(NOT_FOUND, "TM_002", "해당 팀을 찾을 수 없습니다. 팀 정보를 확인해 주세요."),
     TEAM_MEMBER_NOT_FOUND(NOT_FOUND, "TM_003", "해당 팀원을 찾을 수 없습니다. 멤버 정보를 확인해 주세요."),
     UNAUTHORIZED_ROLE_ASSIGNMENT(BAD_REQUEST, "TM_004", "권한이 없는 역할 지정입니다. 적절한 권한을 가진 사용자만 역할을 지정할 수 있습니다."),
+    TEAM_NAME_DUPLICATED(BAD_REQUEST, "TM_005", "팀 이름은 중복될 수 없습니다."),
 
     // 프로젝트(Project) - PR
     PROJECT_NOT_FOUND(NOT_FOUND, "PR_001", "해당 프로젝트를 찾을 수 없습니다. 프로젝트 정보를 확인해 주세요."),

--- a/src/main/java/com/growup/pms/common/util/CookieUtil.java
+++ b/src/main/java/com/growup/pms/common/util/CookieUtil.java
@@ -13,6 +13,7 @@ public final class CookieUtil {
         cookie.setHttpOnly(true);
         cookie.setSecure(true);
         cookie.setPath("/");
+        // TODO: 프론트 서버가 배포되고 도메인이 부여된 이후로는 반드시 아래의 설정 값을 변경해야 함
         cookie.setDomain("localhost");
         cookie.setMaxAge(maxAge);
         response.addCookie(cookie);
@@ -23,6 +24,7 @@ public final class CookieUtil {
         cookie.setHttpOnly(true);
         cookie.setSecure(true);
         cookie.setPath("/");
+        // TODO: 프론트 서버가 배포되고 도메인이 부여된 이후로는 반드시 아래의 설정 값을 변경해야 함
         cookie.setDomain("localhost");
         cookie.setMaxAge(0);
         response.addCookie(cookie);

--- a/src/main/java/com/growup/pms/role/repository/RoleRepository.java
+++ b/src/main/java/com/growup/pms/role/repository/RoleRepository.java
@@ -4,12 +4,15 @@ import com.growup.pms.common.exception.code.ErrorCode;
 import com.growup.pms.common.exception.exceptions.BusinessException;
 import com.growup.pms.role.domain.Role;
 import com.growup.pms.role.domain.RoleType;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RoleRepository extends JpaRepository<Role, Long> {
-    Optional<Role> findByTypeAndName(RoleType type, String name);
 
+    List<Role> findByType(RoleType type);
+
+    Optional<Role> findByTypeAndName(RoleType type, String name);
 
     default Role findByTypeAndNameOrThrow(RoleType type, String name) {
         return findByTypeAndName(type, name)

--- a/src/main/java/com/growup/pms/team/repository/TeamRepository.java
+++ b/src/main/java/com/growup/pms/team/repository/TeamRepository.java
@@ -13,6 +13,8 @@ public interface TeamRepository extends JpaRepository<Team, Long> {
         WHERE t.id = :teamId AND t.creator.id = :userId""")
     boolean isUserTeamLeader(Long teamId, Long userId);
 
+    boolean existsByName(String name);
+
     default Team findByIdOrThrow(Long id) {
         return findById(id).orElseThrow(() -> new BusinessException(ErrorCode.TEAM_NOT_FOUND));
     }

--- a/src/main/java/com/growup/pms/team/service/TeamService.java
+++ b/src/main/java/com/growup/pms/team/service/TeamService.java
@@ -48,10 +48,7 @@ public class TeamService {
         User creator = userRepository.findByIdOrThrow(creatorId);
         Team team = teamRepository.save(command.toEntity(creator));
 
-        List<TeamCoworkerCommand> coworkers = new ArrayList<>();
-        coworkers.add(new TeamCoworkerCommand(creatorId, TeamRole.HEAD.getRoleName()));
-        coworkers.addAll(command.coworkers());
-        inviteAllUsersToTeam(team, coworkers);
+        inviteAllUsersToTeam(team, command.coworkers());
         return team.getId();
     }
 
@@ -84,6 +81,13 @@ public class TeamService {
                 ));
 
         List<TeamUser> invitedUsers = new ArrayList<>();
+        invitedUsers.add(TeamUser.builder()
+                .user(newTeam.getCreator())
+                .role(roles.get(TeamRole.HEAD.getRoleName()))
+                .team(newTeam)
+                .isPendingApproval(false)
+                .build());
+
         for (var coworker : coworkers) {
             if (!roles.containsKey(coworker.roleName())) {
                 continue;
@@ -93,6 +97,7 @@ public class TeamService {
                     .team(newTeam)
                     .user(userRepository.findByIdOrThrow(coworker.userId()))
                     .role(roles.get(coworker.roleName()))
+                    .isPendingApproval(true)
                     .build());
         }
         teamUserRepository.saveAll(invitedUsers);

--- a/src/main/java/com/growup/pms/team/service/TeamService.java
+++ b/src/main/java/com/growup/pms/team/service/TeamService.java
@@ -1,14 +1,28 @@
 package com.growup.pms.team.service;
 
+import com.growup.pms.common.exception.code.ErrorCode;
+import com.growup.pms.common.exception.exceptions.BusinessException;
 import com.growup.pms.project.service.ProjectService;
+import com.growup.pms.role.domain.Role;
+import com.growup.pms.role.domain.RoleType;
+import com.growup.pms.role.domain.TeamRole;
+import com.growup.pms.role.repository.RoleRepository;
 import com.growup.pms.team.controller.dto.response.TeamResponse;
 import com.growup.pms.team.domain.Team;
+import com.growup.pms.team.domain.TeamUser;
 import com.growup.pms.team.domain.TeamUserId;
 import com.growup.pms.team.repository.TeamRepository;
 import com.growup.pms.team.repository.TeamUserRepository;
 import com.growup.pms.team.service.dto.TeamCreateCommand;
+import com.growup.pms.team.service.dto.TeamCreateCommand.TeamCoworkerCommand;
 import com.growup.pms.team.service.dto.TeamUpdateCommand;
+import com.growup.pms.user.domain.User;
 import com.growup.pms.user.repository.UserRepository;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,16 +35,24 @@ public class TeamService {
     private final UserRepository userRepository;
     private final TeamUserRepository teamUserRepository;
     private final ProjectService projectService;
+    private final RoleRepository roleRepository;
 
     public TeamResponse getTeam(Long teamId) {
         return TeamResponse.from(teamRepository.findByIdOrThrow(teamId));
     }
 
     @Transactional
-    // TODO: 권한이나 역할이 구현되면 팀 생성 시 coworker 필드에 있는 팀원들을 팀 멤버 테이블에 추가해야 함
     public Long createTeam(Long creatorId, TeamCreateCommand command) {
-        return teamRepository.save(command.toEntity(userRepository.findByIdOrThrow(creatorId)))
-                .getId();
+        validateTeamCreation(creatorId, command);
+
+        User creator = userRepository.findByIdOrThrow(creatorId);
+        Team team = teamRepository.save(command.toEntity(creator));
+
+        List<TeamCoworkerCommand> coworkers = new ArrayList<>();
+        coworkers.add(new TeamCoworkerCommand(creatorId, TeamRole.HEAD.getRoleName()));
+        coworkers.addAll(command.coworkers());
+        inviteAllUsersToTeam(team, coworkers);
+        return team.getId();
     }
 
     @Transactional
@@ -54,8 +76,59 @@ public class TeamService {
         }
     }
 
+    private void inviteAllUsersToTeam(Team newTeam, List<TeamCoworkerCommand> coworkers) {
+        Map<String, Role> roles = roleRepository.findByType(RoleType.TEAM).stream()
+                .collect(Collectors.toMap(
+                        Role::getName,
+                        role -> role
+                ));
+
+        List<TeamUser> invitedUsers = new ArrayList<>();
+        for (var coworker : coworkers) {
+            if (!roles.containsKey(coworker.roleName())) {
+                continue;
+            }
+
+            invitedUsers.add(TeamUser.builder()
+                    .team(newTeam)
+                    .user(userRepository.findByIdOrThrow(coworker.userId()))
+                    .role(roles.get(coworker.roleName()))
+                    .build());
+        }
+        teamUserRepository.saveAll(invitedUsers);
+    }
+
     private void removeTeam(Long teamId) {
         projectService.deleteAllProjectsForTeam(teamId);
         teamUserRepository.deleteAllByTeamId(teamId);
+    }
+
+    private void validateTeamCreation(Long creatorId, TeamCreateCommand command) {
+        validateTeamNameDuplication(command.teamName());
+        validateNoDuplicateMembers(creatorId, command.coworkers());
+        validateMemberRoles(command.coworkers());
+    }
+
+    private void validateTeamNameDuplication(String teamName) {
+        if (teamRepository.existsByName(teamName)) {
+            throw new BusinessException(ErrorCode.TEAM_NAME_DUPLICATED);
+        }
+    }
+
+    private void validateNoDuplicateMembers(Long creatorId, List<TeamCoworkerCommand> coworkers) {
+        Set<Long> userIds = coworkers.stream()
+                .map(TeamCoworkerCommand::userId)
+                .collect(Collectors.toSet());
+        if (userIds.size() != coworkers.size() || userIds.contains(creatorId)) {
+            throw new BusinessException(ErrorCode.INVALID_DATA_FORMAT);
+        }
+    }
+
+    private void validateMemberRoles(List<TeamCoworkerCommand> coworkers) {
+        boolean hasHead = coworkers.stream()
+                .anyMatch(c -> TeamRole.HEAD.getRoleName().equals(c.roleName()));
+        if (hasHead) {
+            throw new BusinessException(ErrorCode.INVALID_DATA_FORMAT);
+        }
     }
 }

--- a/src/main/resources/static/docs/openapi3.yaml
+++ b/src/main/resources/static/docs/openapi3.yaml
@@ -94,55 +94,6 @@ paths:
       responses:
         "201":
           description: "201"
-    patch:
-      tags:
-      - User
-      summary: 현재 사용자 정보 변경
-      description: 현재 로그인한 사용자의 정보를 변경합니다.
-      operationId: user-controller-v1-docs-test/유저_정보_변경_api_문서를_생성한다
-      parameters:
-      - name: Content-Type
-        in: header
-        description: application/json
-        required: true
-        schema:
-          type: string
-        example: application/json
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/api-v1-user-2119753624'
-            examples:
-              user-controller-v1-docs-test/유저_정보_변경_api_문서를_생성한다:
-                value: |-
-                  {
-                    "nickname" : "wlshooo",
-                    "bio" : "신입입니다. 잘 부탁드려요!",
-                    "profileImageName" : "d4657d96-064e-4899-b13d-9bdda2840adc.png"
-                  }
-      responses:
-        "200":
-          description: "200"
-          headers:
-            Content-Type:
-              description: application/json
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/api-v1-user1641830135'
-              examples:
-                user-controller-v1-docs-test/유저_정보_변경_api_문서를_생성한다:
-                  value: |-
-                    {
-                      "userId" : 1,
-                      "nickname" : "wlshooo",
-                      "profileImageName" : "d4657d96-064e-4899-b13d-9bdda2840adc.png",
-                      "bio" : "신입입니다. 잘 부탁드려요!",
-                      "links" : null
-                    }
   /api/v1/team/{id}:
     get:
       tags:
@@ -214,27 +165,6 @@ paths:
       responses:
         "204":
           description: "204"
-  /api/v1/user/links:
-    patch:
-      tags:
-      - User
-      summary: 사용자 링크 변경
-      description: 현재 로그인한 사용자의 링크를 변경합니다.
-      operationId: user-controller-v1-docs-test/사용자_링크_변경_api_문서를_생성한다
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/api-v1-user-links551251672'
-            examples:
-              user-controller-v1-docs-test/사용자_링크_변경_api_문서를_생성한다:
-                value: |-
-                  {
-                    "links" : [ "http://github.com", "http://blog.example.com", "http://GU-99.com", "http://longBright.com" ]
-                  }
-      responses:
-        "200":
-          description: "200"
   /api/v1/user/login:
     post:
       tags:
@@ -316,57 +246,6 @@ paths:
                       "profileImageName" : "728f3af8-4080-45b1-8b3c-d25e5e073dc7.png",
                       "links" : [ "https://github.com/growup" ]
                     }
-  /api/v1/user/nickname:
-    post:
-      tags:
-      - User
-      summary: 닉네임 중복 검사
-      description: 닉네임이 서버에 존재하는지 확인합니다.
-      operationId: user-controller-v1-docs-test/닉네임_중복_검사_api_문서를_생성한다
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/api-v1-user-nickname-1132561407'
-            examples:
-              user-controller-v1-docs-test/닉네임_중복_검사_api_문서를_생성한다:
-                value: |-
-                  {
-                    "nickname" : "브라운"
-                  }
-      responses:
-        "200":
-          description: "200"
-  /api/v1/user/password:
-    patch:
-      tags:
-      - User
-      summary: 비밀번호 변경
-      description: 새로운 비밀번호를 통해 사용자의 기존 비밀번호를 변경한다.
-      operationId: user-controller-v1-docs-test/비밀번호_변경_api_문서를_생성한다
-      parameters:
-      - name: Content-Type
-        in: header
-        description: application/json
-        required: true
-        schema:
-          type: string
-        example: application/json
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/api-v1-user-password1866472967'
-            examples:
-              user-controller-v1-docs-test/비밀번호_변경_api_문서를_생성한다:
-                value: |-
-                  {
-                    "password" : "test1234!@#$",
-                    "newPassword" : "test2345!@#$"
-                  }
-      responses:
-        "200":
-          description: "200"
   /api/v1/user/refresh:
     post:
       tags:
@@ -1039,28 +918,6 @@ paths:
                     {
                       "username" : "brown"
                     }
-  /api/v1/user/verify/code:
-    post:
-      tags:
-      - User
-      summary: 이메일 인증 코드 확인
-      description: 인증 코드와 이메일로 이메일 인증을 검사한다.
-      operationId: user-controller-v1-docs-test/이메일_인증_코드_검사_api_문서를_생성한다
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/api-v1-user-verify-code1380844528'
-            examples:
-              user-controller-v1-docs-test/이메일_인증_코드_검사_api_문서를_생성한다:
-                value: |-
-                  {
-                    "email" : "test@test.com",
-                    "verificationCode" : "123456"
-                  }
-      responses:
-        "200":
-          description: "200"
   /api/v1/user/verify/send:
     post:
       tags:
@@ -1896,18 +1753,6 @@ components:
         username:
           type: string
           description: 사용자 아이디
-    api-v1-user-links551251672:
-      type: object
-      properties:
-        links:
-          type: array
-          description: 링크 목록
-          items:
-            oneOf:
-            - type: object
-            - type: boolean
-            - type: string
-            - type: number
     api-v1-user-recover-username-1963233032:
       type: object
       properties:
@@ -1917,15 +1762,6 @@ components:
         verificationCode:
           type: string
           description: 이메일로 전송된 인증번호
-    api-v1-user-password1866472967:
-      type: object
-      properties:
-        password:
-          type: string
-          description: 기존 비밀번호
-        newPassword:
-          type: string
-          description: 새로운 비밀번호
     api-v1-project-projectId-status-statusId75349813:
       type: object
       properties:
@@ -1954,25 +1790,6 @@ components:
         content:
           type: string
           description: 일정 내용
-    프로젝트 일정 순서변경 요청 예시입니다.:
-      title: 프로젝트 일정 순서변경 요청 예시입니다.
-      type: object
-      properties:
-        tasks:
-          type: array
-          description: 프로젝트 일정 순서 변경 목록
-          items:
-            type: object
-            properties:
-              statusId:
-                type: number
-                description: 상태 PK
-              sortOrder:
-                type: number
-                description: 일정 정렬 순서
-              taskId:
-                type: number
-                description: 일정 PK
     api-v1-team-teamId-project-557506802:
       type: array
       description: 팀 ID에 해당하는 프로젝트 목록
@@ -2001,6 +1818,25 @@ components:
             type: string
             description: 프로젝트 변경일시
         description: 팀 ID에 해당하는 프로젝트 목록
+    프로젝트 일정 순서변경 요청 예시입니다.:
+      title: 프로젝트 일정 순서변경 요청 예시입니다.
+      type: object
+      properties:
+        tasks:
+          type: array
+          description: 프로젝트 일정 순서 변경 목록
+          items:
+            type: object
+            properties:
+              statusId:
+                type: number
+                description: 상태 PK
+              sortOrder:
+                type: number
+                description: 일정 정렬 순서
+              taskId:
+                type: number
+                description: 일정 PK
     api-v1-user-me-752510290:
       type: object
       properties:
@@ -2082,18 +1918,6 @@ components:
         taskId:
           type: number
           description: 프로젝트 일정 식별자
-    api-v1-user-2119753624:
-      type: object
-      properties:
-        profileImageName:
-          type: string
-          description: 프로필 이미지
-        nickname:
-          type: string
-          description: 닉네임
-        bio:
-          type: string
-          description: 자기소개
     api-v1-user-recover-username1645263616:
       type: object
       properties:
@@ -2262,21 +2086,6 @@ components:
         username:
           type: string
           description: 아이디
-    api-v1-user1641830135:
-      type: object
-      properties:
-        profileImageName:
-          type: string
-          description: 프로필 이미지 이름
-        nickname:
-          type: string
-          description: 닉네임
-        bio:
-          type: string
-          description: 자기소개
-        userId:
-          type: number
-          description: 사용자 아이디
     api-v1-user-recover-password546453054:
       type: object
       properties:
@@ -2353,6 +2162,15 @@ components:
         projectId:
           type: number
           description: 프로젝트 식별자
+    api-v1-team-teamId-invitation-1262545139:
+      type: object
+      properties:
+        roleName:
+          type: string
+          description: 초대할 사용자의 역할명
+        userId:
+          type: number
+          description: 초대할 사용자 ID
     프로젝트원 역할 변경 요청 예시 입니다.:
       title: 프로젝트원 역할 변경 요청 예시 입니다.
       type: object
@@ -2372,15 +2190,6 @@ components:
         colorCode:
           type: string
           description: 색상 코드
-    api-v1-team-teamId-invitation-1262545139:
-      type: object
-      properties:
-        roleName:
-          type: string
-          description: 초대할 사용자의 역할명
-        userId:
-          type: number
-          description: 초대할 사용자 ID
     api-v1-project-projectId-status-order1030631579:
       type: object
       properties:
@@ -2475,18 +2284,3 @@ components:
         content:
           type: string
           description: 프로젝트 설명
-    api-v1-user-verify-code1380844528:
-      type: object
-      properties:
-        email:
-          type: string
-          description: 이메일
-        verificationCode:
-          type: string
-          description: 인증 코드
-    api-v1-user-nickname-1132561407:
-      type: object
-      properties:
-        nickname:
-          type: string
-          description: 검사할 닉네임

--- a/src/main/resources/static/docs/openapi3.yaml
+++ b/src/main/resources/static/docs/openapi3.yaml
@@ -47,7 +47,7 @@ paths:
                     "content" : "코드 한 줄에 커피 한 잔, 우리는 카페인으로 움직이는 팀입니다!",
                     "coworkers" : [ {
                       "userId" : 2,
-                      "roleName" : "Mate"
+                      "roleName" : "MATE"
                     } ]
                   }
       responses:
@@ -94,6 +94,55 @@ paths:
       responses:
         "201":
           description: "201"
+    patch:
+      tags:
+      - User
+      summary: 현재 사용자 정보 변경
+      description: 현재 로그인한 사용자의 정보를 변경합니다.
+      operationId: user-controller-v1-docs-test/유저_정보_변경_api_문서를_생성한다
+      parameters:
+      - name: Content-Type
+        in: header
+        description: application/json
+        required: true
+        schema:
+          type: string
+        example: application/json
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/api-v1-user-2119753624'
+            examples:
+              user-controller-v1-docs-test/유저_정보_변경_api_문서를_생성한다:
+                value: |-
+                  {
+                    "nickname" : "wlshooo",
+                    "bio" : "신입입니다. 잘 부탁드려요!",
+                    "profileImageName" : "d4657d96-064e-4899-b13d-9bdda2840adc.png"
+                  }
+      responses:
+        "200":
+          description: "200"
+          headers:
+            Content-Type:
+              description: application/json
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/api-v1-user1641830135'
+              examples:
+                user-controller-v1-docs-test/유저_정보_변경_api_문서를_생성한다:
+                  value: |-
+                    {
+                      "userId" : 1,
+                      "nickname" : "wlshooo",
+                      "profileImageName" : "d4657d96-064e-4899-b13d-9bdda2840adc.png",
+                      "bio" : "신입입니다. 잘 부탁드려요!",
+                      "links" : null
+                    }
   /api/v1/team/{id}:
     get:
       tags:
@@ -165,6 +214,27 @@ paths:
       responses:
         "204":
           description: "204"
+  /api/v1/user/links:
+    patch:
+      tags:
+      - User
+      summary: 사용자 링크 변경
+      description: 현재 로그인한 사용자의 링크를 변경합니다.
+      operationId: user-controller-v1-docs-test/사용자_링크_변경_api_문서를_생성한다
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/api-v1-user-links551251672'
+            examples:
+              user-controller-v1-docs-test/사용자_링크_변경_api_문서를_생성한다:
+                value: |-
+                  {
+                    "links" : [ "http://github.com", "http://blog.example.com", "http://GU-99.com", "http://longBright.com" ]
+                  }
+      responses:
+        "200":
+          description: "200"
   /api/v1/user/login:
     post:
       tags:
@@ -246,6 +316,57 @@ paths:
                       "profileImageName" : "728f3af8-4080-45b1-8b3c-d25e5e073dc7.png",
                       "links" : [ "https://github.com/growup" ]
                     }
+  /api/v1/user/nickname:
+    post:
+      tags:
+      - User
+      summary: 닉네임 중복 검사
+      description: 닉네임이 서버에 존재하는지 확인합니다.
+      operationId: user-controller-v1-docs-test/닉네임_중복_검사_api_문서를_생성한다
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/api-v1-user-nickname-1132561407'
+            examples:
+              user-controller-v1-docs-test/닉네임_중복_검사_api_문서를_생성한다:
+                value: |-
+                  {
+                    "nickname" : "브라운"
+                  }
+      responses:
+        "200":
+          description: "200"
+  /api/v1/user/password:
+    patch:
+      tags:
+      - User
+      summary: 비밀번호 변경
+      description: 새로운 비밀번호를 통해 사용자의 기존 비밀번호를 변경한다.
+      operationId: user-controller-v1-docs-test/비밀번호_변경_api_문서를_생성한다
+      parameters:
+      - name: Content-Type
+        in: header
+        description: application/json
+        required: true
+        schema:
+          type: string
+        example: application/json
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/api-v1-user-password1866472967'
+            examples:
+              user-controller-v1-docs-test/비밀번호_변경_api_문서를_생성한다:
+                value: |-
+                  {
+                    "password" : "test1234!@#$",
+                    "newPassword" : "test2345!@#$"
+                  }
+      responses:
+        "200":
+          description: "200"
   /api/v1/user/refresh:
     post:
       tags:
@@ -918,6 +1039,28 @@ paths:
                     {
                       "username" : "brown"
                     }
+  /api/v1/user/verify/code:
+    post:
+      tags:
+      - User
+      summary: 이메일 인증 코드 확인
+      description: 인증 코드와 이메일로 이메일 인증을 검사한다.
+      operationId: user-controller-v1-docs-test/이메일_인증_코드_검사_api_문서를_생성한다
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/api-v1-user-verify-code1380844528'
+            examples:
+              user-controller-v1-docs-test/이메일_인증_코드_검사_api_문서를_생성한다:
+                value: |-
+                  {
+                    "email" : "test@test.com",
+                    "verificationCode" : "123456"
+                  }
+      responses:
+        "200":
+          description: "200"
   /api/v1/user/verify/send:
     post:
       tags:
@@ -1753,6 +1896,18 @@ components:
         username:
           type: string
           description: 사용자 아이디
+    api-v1-user-links551251672:
+      type: object
+      properties:
+        links:
+          type: array
+          description: 링크 목록
+          items:
+            oneOf:
+            - type: object
+            - type: boolean
+            - type: string
+            - type: number
     api-v1-user-recover-username-1963233032:
       type: object
       properties:
@@ -1762,6 +1917,15 @@ components:
         verificationCode:
           type: string
           description: 이메일로 전송된 인증번호
+    api-v1-user-password1866472967:
+      type: object
+      properties:
+        password:
+          type: string
+          description: 기존 비밀번호
+        newPassword:
+          type: string
+          description: 새로운 비밀번호
     api-v1-project-projectId-status-statusId75349813:
       type: object
       properties:
@@ -1790,6 +1954,25 @@ components:
         content:
           type: string
           description: 일정 내용
+    프로젝트 일정 순서변경 요청 예시입니다.:
+      title: 프로젝트 일정 순서변경 요청 예시입니다.
+      type: object
+      properties:
+        tasks:
+          type: array
+          description: 프로젝트 일정 순서 변경 목록
+          items:
+            type: object
+            properties:
+              statusId:
+                type: number
+                description: 상태 PK
+              sortOrder:
+                type: number
+                description: 일정 정렬 순서
+              taskId:
+                type: number
+                description: 일정 PK
     api-v1-team-teamId-project-557506802:
       type: array
       description: 팀 ID에 해당하는 프로젝트 목록
@@ -1818,25 +2001,6 @@ components:
             type: string
             description: 프로젝트 변경일시
         description: 팀 ID에 해당하는 프로젝트 목록
-    프로젝트 일정 순서변경 요청 예시입니다.:
-      title: 프로젝트 일정 순서변경 요청 예시입니다.
-      type: object
-      properties:
-        tasks:
-          type: array
-          description: 프로젝트 일정 순서 변경 목록
-          items:
-            type: object
-            properties:
-              statusId:
-                type: number
-                description: 상태 PK
-              sortOrder:
-                type: number
-                description: 일정 정렬 순서
-              taskId:
-                type: number
-                description: 일정 PK
     api-v1-user-me-752510290:
       type: object
       properties:
@@ -1918,6 +2082,18 @@ components:
         taskId:
           type: number
           description: 프로젝트 일정 식별자
+    api-v1-user-2119753624:
+      type: object
+      properties:
+        profileImageName:
+          type: string
+          description: 프로필 이미지
+        nickname:
+          type: string
+          description: 닉네임
+        bio:
+          type: string
+          description: 자기소개
     api-v1-user-recover-username1645263616:
       type: object
       properties:
@@ -2086,6 +2262,21 @@ components:
         username:
           type: string
           description: 아이디
+    api-v1-user1641830135:
+      type: object
+      properties:
+        profileImageName:
+          type: string
+          description: 프로필 이미지 이름
+        nickname:
+          type: string
+          description: 닉네임
+        bio:
+          type: string
+          description: 자기소개
+        userId:
+          type: number
+          description: 사용자 아이디
     api-v1-user-recover-password546453054:
       type: object
       properties:
@@ -2162,15 +2353,6 @@ components:
         projectId:
           type: number
           description: 프로젝트 식별자
-    api-v1-team-teamId-invitation-1262545139:
-      type: object
-      properties:
-        roleName:
-          type: string
-          description: 초대할 사용자의 역할명
-        userId:
-          type: number
-          description: 초대할 사용자 ID
     프로젝트원 역할 변경 요청 예시 입니다.:
       title: 프로젝트원 역할 변경 요청 예시 입니다.
       type: object
@@ -2190,6 +2372,15 @@ components:
         colorCode:
           type: string
           description: 색상 코드
+    api-v1-team-teamId-invitation-1262545139:
+      type: object
+      properties:
+        roleName:
+          type: string
+          description: 초대할 사용자의 역할명
+        userId:
+          type: number
+          description: 초대할 사용자 ID
     api-v1-project-projectId-status-order1030631579:
       type: object
       properties:
@@ -2284,3 +2475,18 @@ components:
         content:
           type: string
           description: 프로젝트 설명
+    api-v1-user-verify-code1380844528:
+      type: object
+      properties:
+        email:
+          type: string
+          description: 이메일
+        verificationCode:
+          type: string
+          description: 인증 코드
+    api-v1-user-nickname-1132561407:
+      type: object
+      properties:
+        nickname:
+          type: string
+          description: 검사할 닉네임

--- a/src/test/java/com/growup/pms/test/fixture/team/builder/TeamCreateRequestTestBuilder.java
+++ b/src/test/java/com/growup/pms/test/fixture/team/builder/TeamCreateRequestTestBuilder.java
@@ -2,6 +2,7 @@ package com.growup.pms.test.fixture.team.builder;
 
 import static com.growup.pms.test.fixture.team.builder.TeamCreateRequestTestBuilder.TeamCoworkerRequestTestBuilder.초대된_사용자는;
 
+import com.growup.pms.role.domain.TeamRole;
 import com.growup.pms.team.controller.dto.request.TeamCreateRequest;
 import com.growup.pms.team.controller.dto.request.TeamCreateRequest.TeamCoworkerRequest;
 import java.util.List;
@@ -46,7 +47,7 @@ public class TeamCreateRequestTestBuilder {
 
     public static class TeamCoworkerRequestTestBuilder {
         private Long userId = 2L;
-        private String roleName = "Mate";
+        private String roleName = TeamRole.MATE.getRoleName();
 
         public static TeamCoworkerRequestTestBuilder 초대된_사용자는() {
             return new TeamCoworkerRequestTestBuilder();


### PR DESCRIPTION
## PR Type

- [x] **\[Feat\]** 🎨 새로운 기능을 추가했어요.
- [x] **\[Test\]** 🧪 테스트 코드를 추가/삭제/변경 했어요.
- [x] **\[Comment\]** 🖋 필요한 주석 추가/삭제/변경 했어요.

## Related Issues

- close #304 

## What does this PR do?

- [x] 완성되지 않은 팀 생성 로직을 마저 완성시킴
- [x] 유닛 테스트를 보강함

## Other information
아래의 로직을 새롭게 추가하고, 팀 사용자 테이블에 초대된 사용자들을 모두 추가하는 로직을 넣었습니다.

1. 초대된 사용자 목록에 팀장의 ID가 있으면 생성을 거부함
2. 초대된 사용자 목록에 중복된 ID가 있으면 생성을 거부함
3. 초대된 사용자의 역할은 HEAD가 아니여야 함(LEADER 혹은 MATE여야 함)