### PR TITLE
Chore: #361 API 문서 생성을 위해 빌드 시에 테스트 과정을 포함시킴

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -20,13 +20,7 @@ jobs:
         run: chmod +x gradlew
 
       - name: Build with Gradle
-        run: ./gradlew build --no-daemon -x test
-
-      - name: Download OpenAPI spec
-        uses: actions/download-artifact@v4
-        with:
-          name: openapi-spec-latest
-          path: src/main/resources/static/docs/openapi3.yaml
+        run: ./gradlew build --no-daemon
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -46,13 +46,6 @@ jobs:
         with:
           report_paths: '**/build/test-results/test/TEST-*.xml'
 
-      - name: Archive OpenAPI spec
-        uses: actions/upload-artifact@v4
-        with:
-          name: openapi-spec-latest
-          path: src/main/resources/static/docs/openapi3.yaml
-          retention-days: 7
-
       - name: Archive coverage data
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## PR Type

- [x] **\[Chore\]** 🛒 빌드 프로세스 변경, 의존성 패키지 업데이트 했어요.

## Related Issues

- close #361 

## What does this PR do?

- [x] API 문서 생성을 위해 빌드 시에 테스트 과정도 포함시킴

## Other information

PR이 올라오면 테스트가 돌아가는데 이 과정에서 생성되는 `openapi3.yaml` 파일을 `develop` 브랜치의 `push` 이벤트가 발생했을 때 실행되는 액션에서 가져오기가 좀 애매해서 빌드 시에 테스트까지 같이 포함시켰습니다. :sweat_smile: (기본적으로 브랜치마다 공간이 있음)

마지막 PR 테스트 잡에서 만들어진 `openapi3.yaml` 파일이 `push` 이벤트에서 가져왔을 때 빌드된 버전의 API 문서라는 보증도 얻기가 힘들어서, 별도의 문서 서버(`push` 이벤트가 발생하면 pull 방식으로 별도의 서버에서 빌드를 트리거하는 서버)가 있으면 또 어떨까 싶기는 했는데 비용 문제도 있고 이게 최선이라고 생각했습니다. :joy: 