### PR TITLE
Feat: #375 닉네임 부여 로직 변경

### DIFF
--- a/src/main/java/com/growup/pms/auth/service/oauth/OauthLoginService.java
+++ b/src/main/java/com/growup/pms/auth/service/oauth/OauthLoginService.java
@@ -9,6 +9,7 @@ import com.growup.pms.common.exception.code.ErrorCode;
 import com.growup.pms.common.exception.exceptions.BusinessException;
 import com.growup.pms.common.security.jwt.JwtTokenProvider;
 import com.growup.pms.common.security.jwt.dto.TokenResponse;
+import com.growup.pms.common.util.NicknameUtil;
 import com.growup.pms.user.domain.Provider;
 import com.growup.pms.user.domain.User;
 import com.growup.pms.user.domain.UserProfile;
@@ -25,6 +26,7 @@ public class OauthLoginService {
     private final UserRepository userRepository;
     private final JwtTokenProvider jwtTokenProvider;
     private final RefreshTokenService redisRefreshTokenService;
+    private final NicknameUtil nicknameUtil;
 
     public TokenResponse authenticate(Provider provider, OauthUserLoginCommand command) {
         Oauth2Service oAuth2Service = getOauth2Service(provider);
@@ -33,9 +35,8 @@ public class OauthLoginService {
         OauthProfile profile = oAuth2Service.requestProfile(provider, accessToken);
 
         String email = profile.getEmail();
-        String nickname = profile.getNickname();
 
-        User user = userRepository.findByEmail(email).orElseGet(() -> joinUser(email, nickname, provider));
+        User user = userRepository.findByEmail(email).orElseGet(() -> joinUser(email, provider));
         SecurityUser securityUser = convertSecurityUser(user);
 
         TokenResponse newToken = jwtTokenProvider.generateToken(securityUser);
@@ -59,13 +60,15 @@ public class OauthLoginService {
                 .build();
     }
 
-    private User joinUser(String email, String nickname, Provider provider) {
+    private User joinUser(String email, Provider provider) {
+        String newNickname = nicknameUtil.generateNickname();
+
         User user = User.builder()
                 .provider(provider)
                 .email(email)
                 .username(email)
                 .profile(UserProfile.builder()
-                        .nickname(nickname)
+                        .nickname(newNickname)
                         .build())
                 .build();
 

--- a/src/main/java/com/growup/pms/auth/service/oauth/OauthLoginService.java
+++ b/src/main/java/com/growup/pms/auth/service/oauth/OauthLoginService.java
@@ -9,7 +9,7 @@ import com.growup.pms.common.exception.code.ErrorCode;
 import com.growup.pms.common.exception.exceptions.BusinessException;
 import com.growup.pms.common.security.jwt.JwtTokenProvider;
 import com.growup.pms.common.security.jwt.dto.TokenResponse;
-import com.growup.pms.common.util.NicknameUtil;
+import com.growup.pms.common.util.RandomNicknameGenerator;
 import com.growup.pms.user.domain.Provider;
 import com.growup.pms.user.domain.User;
 import com.growup.pms.user.domain.UserProfile;
@@ -27,7 +27,6 @@ public class OauthLoginService {
     private final UserRepository userRepository;
     private final JwtTokenProvider jwtTokenProvider;
     private final RefreshTokenService redisRefreshTokenService;
-    private final NicknameUtil nicknameUtil;
 
     @Transactional
     public TokenResponse authenticate(Provider provider, OauthUserLoginCommand command) {
@@ -63,7 +62,7 @@ public class OauthLoginService {
     }
 
     private User joinUser(String email, Provider provider) {
-        String newNickname = nicknameUtil.generateNickname();
+        String newNickname = RandomNicknameGenerator.generateNickname();
 
         User user = User.builder()
                 .provider(provider)

--- a/src/main/java/com/growup/pms/auth/service/oauth/OauthLoginService.java
+++ b/src/main/java/com/growup/pms/auth/service/oauth/OauthLoginService.java
@@ -16,6 +16,7 @@ import com.growup.pms.user.domain.UserProfile;
 import com.growup.pms.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -28,6 +29,7 @@ public class OauthLoginService {
     private final RefreshTokenService redisRefreshTokenService;
     private final NicknameUtil nicknameUtil;
 
+    @Transactional
     public TokenResponse authenticate(Provider provider, OauthUserLoginCommand command) {
         Oauth2Service oAuth2Service = getOauth2Service(provider);
 

--- a/src/main/java/com/growup/pms/common/util/NicknameUtil.java
+++ b/src/main/java/com/growup/pms/common/util/NicknameUtil.java
@@ -1,11 +1,10 @@
 package com.growup.pms.common.util;
 
 import java.util.concurrent.ThreadLocalRandom;
-import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.springframework.stereotype.Component;
 
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor
 @Component
 public class NicknameUtil {
 
@@ -20,7 +19,7 @@ public class NicknameUtil {
             "장미", "튤립", "백합", "국화", "진달래", "나팔꽃", "목련", "봉숭아", "제비꽃", "해바라기", "할미꽃",
             "무궁화", "벚꽃", "개나리", "매화", "산수유", "민들레", "메리골드", "라일락", "아이비", "옥잠화", "감나무",
             "살구나무", "포도나무", "수국", "아마란스", "코스모스", "철쭉", "소나무", "느티나무", "자목련",
-            "해바라기", "까마중", "산딸기", "비비추", "봉숭아", "살구나무", "포플러", "등나무", "마가렛"
+            "데이지", "까마중", "산딸기", "비비추", "장미", "튤립", "포플러", "등나무", "마가렛"
     };
 
     public String generateNickname() {

--- a/src/main/java/com/growup/pms/common/util/NicknameUtil.java
+++ b/src/main/java/com/growup/pms/common/util/NicknameUtil.java
@@ -1,0 +1,33 @@
+package com.growup.pms.common.util;
+
+import java.util.concurrent.ThreadLocalRandom;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@Component
+public class NicknameUtil {
+
+    private final String[] ADJECTIVES = {
+            "간편한", "건강한", "고급스런", "공정한", "급한", "깨끗한", "끈기있는", "달콤한", "단정한", "따뜻한",
+            "똑똑한", "멋진", "미묘한", "밝은", "빠른", "소중한", "신선한", "아름다운", "안전한", "완벽한",
+            "기쁜", "즐거운", "혁신적인", "창의적인", "친절한", "용감한", "재미있는", "부드러운", "정직한", "깨달은",
+            "넉넉한", "행복한", "유능한", "경쾌한", "신비로운", "유쾌한", "명랑한", "긍정적인", "정중한", "상냥한"
+    };
+
+    private final String[] NOUNS = {
+            "장미", "튤립", "백합", "국화", "진달래", "나팔꽃", "목련", "봉숭아", "제비꽃", "해바라기", "할미꽃",
+            "무궁화", "벚꽃", "개나리", "매화", "산수유", "민들레", "메리골드", "라일락", "아이비", "옥잠화", "감나무",
+            "살구나무", "포도나무", "수국", "아마란스", "코스모스", "철쭉", "소나무", "느티나무", "자목련",
+            "해바라기", "까마중", "산딸기", "비비추", "봉숭아", "살구나무", "포플러", "등나무", "마가렛"
+    };
+
+    public String generateNickname() {
+        String adjective = ADJECTIVES[ThreadLocalRandom.current().nextInt(ADJECTIVES.length)];
+        String noun = NOUNS[ThreadLocalRandom.current().nextInt(NOUNS.length)];
+        String randomValue = String.valueOf(ThreadLocalRandom.current().nextInt(99999));
+
+        return adjective + noun + randomValue;
+    }
+}

--- a/src/main/java/com/growup/pms/common/util/RandomNicknameGenerator.java
+++ b/src/main/java/com/growup/pms/common/util/RandomNicknameGenerator.java
@@ -1,28 +1,27 @@
 package com.growup.pms.common.util;
 
 import java.util.concurrent.ThreadLocalRandom;
+import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
-import org.springframework.stereotype.Component;
 
-@NoArgsConstructor
-@Component
-public class NicknameUtil {
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class RandomNicknameGenerator {
 
-    private final String[] ADJECTIVES = {
+    private static final String[] ADJECTIVES = {
             "간편한", "건강한", "고급스런", "공정한", "급한", "깨끗한", "끈기있는", "달콤한", "단정한", "따뜻한",
             "똑똑한", "멋진", "미묘한", "밝은", "빠른", "소중한", "신선한", "아름다운", "안전한", "완벽한",
             "기쁜", "즐거운", "혁신적인", "창의적인", "친절한", "용감한", "재미있는", "부드러운", "정직한", "깨달은",
             "넉넉한", "행복한", "유능한", "경쾌한", "신비로운", "유쾌한", "명랑한", "긍정적인", "정중한", "상냥한"
     };
 
-    private final String[] NOUNS = {
+    private static final String[] NOUNS = {
             "장미", "튤립", "백합", "국화", "진달래", "나팔꽃", "목련", "봉숭아", "제비꽃", "해바라기", "할미꽃",
             "무궁화", "벚꽃", "개나리", "매화", "산수유", "민들레", "메리골드", "라일락", "아이비", "옥잠화", "감나무",
             "살구나무", "포도나무", "수국", "아마란스", "코스모스", "철쭉", "소나무", "느티나무", "자목련",
-            "데이지", "까마중", "산딸기", "비비추", "장미", "튤립", "포플러", "등나무", "마가렛"
+            "데이지", "까마중", "산딸기", "비비추", "장정", "튤립", "포플러", "등나무", "마가렛"
     };
 
-    public String generateNickname() {
+    public static String generateNickname() {
         String adjective = ADJECTIVES[ThreadLocalRandom.current().nextInt(ADJECTIVES.length)];
         String noun = NOUNS[ThreadLocalRandom.current().nextInt(NOUNS.length)];
         String randomValue = String.valueOf(ThreadLocalRandom.current().nextInt(99999));


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

<!-- 'x'를 이용하여 이 PR에 적용되는 항목을 확인해 주세요. -->

- [x] **\[Fix\]** 🐞 버그를 수정했어요.
- [x] **\[Feat\]** 🎨 새로운 기능을 추가했어요.

## Related Issues
- close #375 
<!--#을 눌러 이슈와 연결해 주세요-->

## What does this PR do?

<!--무엇을 하셨나요?-->

- [x] 닉네임 생성 유틸 추가
- [x] 기존 닉네임 생성 로직 변경

## Other information

<!--참고한 자료, 추가적인 사항, 기타 의견-->
초기 유저에 대한 닉네임 생성 기획이 따로 지정되지 않음에 따라 랜덤으로 생성하는 로직으로 변경하였습니다.
기존 로직으로는 프론트에서 테스트가 진행되지 않아 임의로 변경하였습니다.
더 좋은 아이디어 있으시면 코멘트 부탁드리겠습니다!

++ 현재 닉네임이 중복될 확률은 형용사 40개 , 명사 40개 , 10000개의 숫자 중 한개로 1억 7천만분의 1입니다. 이정도면 충분한건지 의논해보고 싶습니다!