### PR TITLE
Fix: #394 권한 검사 시 마커 애노테이션이 누락되어 ID를 찾지 못하는 문제 수정

### DIFF
--- a/qodana.yaml
+++ b/qodana.yaml
@@ -13,3 +13,6 @@ exclude:
       - build.gradle
       - settings.gradle
   - name: CheckDependencyLicenses
+  - name: NullableProblems
+  - name: DefaultAnnotationParam
+  - name: LoggingSimilarMessage

--- a/src/main/java/com/growup/pms/team/controller/TeamControllerV1.java
+++ b/src/main/java/com/growup/pms/team/controller/TeamControllerV1.java
@@ -87,7 +87,7 @@ public class TeamControllerV1 {
 
     @DeleteMapping("/{teamId}")
     @RequireTeamPermission(TeamPermission.DELETE_TEAM)
-    public ResponseEntity<Void> deleteTeam(@Positive @PathVariable Long teamId) {
+    public ResponseEntity<Void> deleteTeam(@Positive @PathVariable @TeamId Long teamId) {
         teamService.deleteTeam(teamId);
         return ResponseEntity.noContent().build();
     }


### PR DESCRIPTION
## PR Type

- [x] **\[Fix\]** 🐞 버그를 수정했어요.

## Related Issues

- close #394

## What does this PR do?

- [x] [권한 검사 시 필요로 하는 누락된 마커 애노테이션을 추가함](https://github.com/GU-99/grow-up-pms/commit/720b6686cc5fba04a6954f3cd839fdc6c6fca991)
- [x] [Qodana에서 불필요하다고 판단되는 검사는 제외함](https://github.com/GU-99/grow-up-pms/commit/1233dc01f9b8a5540ebe8451c1f8b4b0fd69f0ab)